### PR TITLE
win32 system.Displays

### DIFF
--- a/bridge/api/system/system_windows.go
+++ b/bridge/api/system/system_windows.go
@@ -1,5 +1,55 @@
 package system
 
+import (
+	"tractor.dev/apptron/bridge/platform/win32"
+)
+
 func Displays() (displays []Display) {
+	enumProc := func(monitor win32.HMONITOR, param1 win32.HDC, param2 *win32.RECT, param3 win32.LPARAM) uintptr {
+		rect := param2
+		info := win32.MONITORINFOEX{}
+		devMode := win32.DEVMODE{}
+
+		if win32.GetMonitorInfo(monitor, &info) {
+			if win32.EnumDisplaySettings(&info.DeviceName[0], win32.ENUM_CURRENT_SETTINGS, &devMode) {
+				rect = &win32.RECT{
+					Left:   devMode.DmPosition.X,
+					Right:  devMode.DmPosition.X + win32.LONG(devMode.DmPelsWidth),
+					Top:    devMode.DmPosition.Y,
+					Bottom: devMode.DmPosition.Y + win32.LONG(devMode.DmPelsHeight),
+				}
+			}
+		}
+
+		/*
+			cxLogicl := info.RcMonitor.Right - info.RcMonitor.Left
+			cxPhysical := devMode.DmPelsWidth
+			scaleFactor := float64(cxPhysical) / float64(cxLogicl)
+		*/
+
+		var dpiX win32.UINT
+		var dpiY win32.UINT
+		win32.GetDpiForMonitor(monitor, 0, &dpiX, &dpiY)
+
+		scaleFactor := float64(dpiX) / float64(win32.USER_DEFAULT_SCREEN_DPI)
+
+		displays = append(displays, Display{
+			Name: info.GetDeviceName(),
+			Size: Size{
+				Width:  float64(rect.Right - rect.Left),
+				Height: float64(rect.Bottom - rect.Top),
+			},
+			Position: Position{
+				X: float64(rect.Top),
+				Y: float64(rect.Left),
+			},
+			ScaleFactor: scaleFactor,
+		})
+
+		return uintptr(win32.TRUE)
+	}
+
+	win32.EnumDisplayMonitors(0, nil, enumProc, 0)
+
 	return
 }

--- a/bridge/platform/win32/types.go
+++ b/bridge/platform/win32/types.go
@@ -29,11 +29,15 @@ type HBRUSH HANDLE
 type HINSTANCE HANDLE
 type HMENU HANDLE
 type HBITMAP HANDLE
+type HDC HANDLE
+type HMONITOR HANDLE
 
 type WPARAM UINT_PTR
 type LPARAM LONG_PTR
 type LRESULT LONG_PTR
 type WNDPROC func(hwnd HWND, msg uint32, wparam WPARAM, lparam LPARAM) LRESULT
+
+type MONITORENUMPROC func(unnamedParam1 HMONITOR, unnamedParam2 HDC, unnamedParam3 *RECT, unnamedParam4 LPARAM) uintptr
 
 // https://github.com/AllenDang/w32/blob/ad0a36d80adcd081d5c0dded8e97a009b486d1db/constants.go
 
@@ -145,6 +149,13 @@ const (
 	GWL_USERDATA = (int)(INT_MAX - 21 + 1)
 )
 
+const ENUM_CURRENT_SETTINGS = 0xFFFFFFFF
+
+const CCHDEVICENAME = 32
+const CCHFORMNAME = 32
+
+const USER_DEFAULT_SCREEN_DPI = 96
+
 // https://docs.microsoft.com/en-us/windows/win32/api/windef/ns-windef-point
 type POINT struct {
 	X LONG
@@ -231,3 +242,61 @@ type MENUITEMINFOW struct {
 }
 
 type MENUITEMINFO MENUITEMINFOW
+
+type MONITORINFO struct {
+	CbSize    DWORD
+	RcMonitor RECT
+	RcWork    RECT
+	DwFlags   DWORD
+}
+
+type MONITORINFOEXW struct {
+	MONITORINFO
+	DeviceName [CCHDEVICENAME]uint16
+}
+
+type MONITORINFOEX MONITORINFOEXW
+
+// http://msdn.microsoft.com/en-us/library/windows/desktop/dd183565.aspx
+type DEVMODE struct {
+	DmDeviceName    [CCHDEVICENAME]uint16
+	DmSpecVersion   WORD
+	DmDriverVersion WORD
+	DmSize          WORD
+	DmDriverExtra   WORD
+	DmFields        DWORD
+
+	// union!
+	DmPosition POINT // 64 bytes
+	/*
+		DmOrientation   int16
+		DmPaperSize     int16
+		DmPaperLength   int16
+		DmPaperWidth    int16
+	*/
+	_DmScale         int16
+	_DmCopies        int16
+	_DmDefaultSource int16
+	_DmPrintQuality  int16
+
+	DmColor            int16
+	DmDuplex           int16
+	DmYResolution      int16
+	DmTTOption         int16
+	DmCollate          int16
+	DmFormName         [CCHFORMNAME]WCHAR
+	DmLogPixels        WORD
+	DmBitsPerPel       DWORD
+	DmPelsWidth        DWORD
+	DmPelsHeight       DWORD
+	DmDisplayFlags     DWORD
+	DmDisplayFrequency DWORD
+	DmICMMethod        DWORD
+	DmICMIntent        DWORD
+	DmMediaType        DWORD
+	DmDitherType       DWORD
+	DmReserved1        DWORD
+	DmReserved2        DWORD
+	DmPanningWidth     DWORD
+	DmPanningHeight    DWORD
+}

--- a/bridge/platform/win32/win32.go
+++ b/bridge/platform/win32/win32.go
@@ -17,6 +17,15 @@ var (
 	pExitProcess      = kernel32.NewProc("ExitProcess")
 )
 
+func GetModuleHandle() HINSTANCE {
+	ret, _, _ := pGetModuleHandleW.Call(uintptr(0))
+	return HINSTANCE(ret)
+}
+
+func ExitProcess(exitCode UINT) {
+	pExitProcess.Call(uintptr(exitCode))
+}
+
 var (
 	user32 = syscall.NewLazyDLL("user32.dll")
 
@@ -35,6 +44,9 @@ var (
 	pGetActiveWindow     = user32.NewProc("GetActiveWindow")
 	pSetWindowLongW      = user32.NewProc("SetWindowLongW")
 	pGetWindowLongW      = user32.NewProc("GetWindowLongW")
+	pEnumDisplayMonitors = user32.NewProc("EnumDisplayMonitors")
+	pEnumDisplaySettings = user32.NewProc("EnumDisplaySettingsW")
+	pGetMonitorInfoW     = user32.NewProc("GetMonitorInfoW")
 
 	pCreateMenu       = user32.NewProc("CreateMenu")
 	pCreatePopupMenu  = user32.NewProc("CreatePopupMenu")
@@ -48,27 +60,6 @@ var (
 
 	pSetProcessDpiAwarenessContext = user32.NewProc("SetProcessDpiAwarenessContext")
 )
-
-var (
-	shell32 = syscall.NewLazyDLL("shell32.dll")
-
-	pShell_NotifyIconW = shell32.NewProc("Shell_NotifyIconW")
-)
-
-var (
-	winmm = syscall.NewLazyDLL("winmm.dll")
-
-	pTimeBeginPeriod = winmm.NewProc("timeBeginPeriod")
-)
-
-func GetModuleHandle() HINSTANCE {
-	ret, _, _ := pGetModuleHandleW.Call(uintptr(0))
-	return HINSTANCE(ret)
-}
-
-func ExitProcess(exitCode UINT) {
-	pExitProcess.Call(uintptr(exitCode))
-}
 
 func CreateWindow(className, windowName string, style uint32, x, y, width, height int32, parent, menu, instance HINSTANCE) (HWND, error) {
 	ret, _, err := pCreateWindowExW.Call(
@@ -178,13 +169,27 @@ func GetWindowLongW(hwnd HWND, index int) LONG {
 	return LONG(ret)
 }
 
-func GetCursorPos(pos *POINT) bool {
-	ret, _, _ := pGetCursorPos.Call(uintptr(unsafe.Pointer(pos)))
+func EnumDisplayMonitors(hdc HDC, clip *RECT, enumProc MONITORENUMPROC, data LPARAM) bool {
+	ret, _, _ := pEnumDisplayMonitors.Call(uintptr(hdc), uintptr(unsafe.Pointer(clip)), syscall.NewCallback(enumProc), uintptr(data))
 	return ret != 0
 }
 
-func Shell_NotifyIconW(dwMessage DWORD, nid *NOTIFYICONDATA) bool {
-	ret, _, _ := pShell_NotifyIconW.Call(uintptr(dwMessage), uintptr(unsafe.Pointer(nid)))
+func EnumDisplaySettings(deviceName *uint16, iModeNum DWORD, lpDevMode *DEVMODE) bool {
+	lpDevMode.DmSize = WORD(unsafe.Sizeof(*lpDevMode))
+
+	ret, _, _ := pEnumDisplaySettings.Call(uintptr(unsafe.Pointer(deviceName)), uintptr(iModeNum), uintptr(unsafe.Pointer(lpDevMode)))
+	return ret != 0
+}
+
+func GetMonitorInfo(monitor HMONITOR, info *MONITORINFOEX) bool {
+	info.CbSize = DWORD(unsafe.Sizeof(*info))
+
+	ret, _, _ := pGetMonitorInfoW.Call(uintptr(monitor), uintptr(unsafe.Pointer(info)))
+	return ret != 0
+}
+
+func GetCursorPos(pos *POINT) bool {
+	ret, _, _ := pGetCursorPos.Call(uintptr(unsafe.Pointer(pos)))
 	return ret != 0
 }
 
@@ -250,6 +255,35 @@ func LookupIconIdFromDirectoryEx(bytes *BYTE, icon BOOL, cxDesired int32, cyDesi
 	return int32(result)
 }
 
+var (
+	shell32 = syscall.NewLazyDLL("shell32.dll")
+
+	pShell_NotifyIconW = shell32.NewProc("Shell_NotifyIconW")
+)
+
+func Shell_NotifyIconW(dwMessage DWORD, nid *NOTIFYICONDATA) bool {
+	ret, _, _ := pShell_NotifyIconW.Call(uintptr(dwMessage), uintptr(unsafe.Pointer(nid)))
+	return ret != 0
+}
+
+var (
+	shcore = syscall.NewLazyDLL("shcore.dll")
+
+	// min support Windows 8.1 [desktop apps only]
+	pGetDpiForMonitor = shcore.NewProc("GetDpiForMonitor")
+)
+
+func GetDpiForMonitor(monitor HMONITOR, dpiType uint32 /*MONITOR_DPI_TYPE*/, dpiX *UINT, dpiY *UINT) bool {
+	ret, _, _ := pGetDpiForMonitor.Call(uintptr(monitor), uintptr(dpiType), uintptr(unsafe.Pointer(dpiX)), uintptr(unsafe.Pointer(dpiY)))
+	return ret == 0 /*S_OK*/
+}
+
+var (
+	winmm = syscall.NewLazyDLL("winmm.dll")
+
+	pTimeBeginPeriod = winmm.NewProc("timeBeginPeriod")
+)
+
 //
 // Functions
 //
@@ -294,6 +328,10 @@ func PollEvents() {
 		TranslateMessage(&msg)
 		DispatchMessage(&msg)
 	}
+}
+
+func (info *MONITORINFOEX) GetDeviceName() string {
+	return syscall.UTF16ToString(info.DeviceName[:])
 }
 
 func RegisterWindowClass(className string, instance HINSTANCE, callback WNDPROC) bool {


### PR DESCRIPTION
Should wait to merge #34 first and then change the base branch of this to be main!

Notes:

Scale factor is based on the "make everything bigger" section in the system settings. Should test with multiple monitors with different scaling to see how this holds up. Also scale factor technically on Windows includes an x and a y component. I don't know when these would ever be different or why they do this, but just something to be aware of.

There is also [GetScaleFactorForMonitor](https://docs.microsoft.com/en-us/windows/win32/api/shellscalingapi/nf-shellscalingapi-getscalefactorformonitor), but I'm not 100% sure what the closest thing to NSScreen backingScaleFactor is. Would have to do more reading on it