### PR TITLE
invert y coordinates on macos

### DIFF
--- a/client/events.go
+++ b/client/events.go
@@ -12,6 +12,7 @@ type EventType int
 const (
 	EventNone EventType = iota
 	EventClose
+	EventCreated
 	EventDestroyed
 	EventFocused
 	EventBlurred
@@ -22,7 +23,7 @@ const (
 )
 
 func (e EventType) String() string {
-	return []string{"", "close", "destroy", "focus", "blur", "resize", "move", "menu", "shortcut"}[e]
+	return []string{"", "close", "create", "destroy", "focus", "blur", "resize", "move", "menu", "shortcut"}[e]
 }
 
 type Event struct {

--- a/cmd/debug/main_cmd.go
+++ b/cmd/debug/main_cmd.go
@@ -46,9 +46,9 @@ func main() {
 		Frameless:   false,
 		Resizable:   true,
 		Visible:     true,
-		//Position: window.Position{X: 10, Y: 10},
-		//Size:   client.Size{Width: 360, Height: 240},
-		Center: true,
+		Position:    client.Position{X: 100, Y: 100},
+		//Size:        client.Size{Width: 360, Height: 240},
+		Center: false,
 		HTML: `
 			<!doctype html>
 			<html>
@@ -66,6 +66,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	w1.SetPosition(ctx, client.Position{X: 100, Y: 100})
 
 	fmt.Println("[main] window", w1)
 


### PR DESCRIPTION
This normalizes the position across all platforms to be top-left as 0, 0

Part of #57 