### PR TITLE
saving and restoring window positions

### DIFF
--- a/bridge/api/app/app.go
+++ b/bridge/api/app/app.go
@@ -14,9 +14,10 @@ func init() {
 }
 
 type Options struct {
-	Identifier string
-	Agent      bool // app should not terminate when last window closes
-	Accessory  bool // app should not be task switchable
+	Identifier      string
+	Agent           bool // app should not terminate when last window closes
+	Accessory       bool // app should not be task switchable
+	DisableAutoSave bool // disable window position saving and restoring
 }
 
 func SetMenu(m *menu.Menu) error {

--- a/bridge/api/app/app.go
+++ b/bridge/api/app/app.go
@@ -20,10 +20,6 @@ type Options struct {
 	DisableAutoSave bool // disable window position saving and restoring
 }
 
-func SetMenu(m *menu.Menu) error {
-	return menu.SetMenu(m)
-}
-
 func (m *module) Menu() *menu.Menu {
 	return menu.GetMenu()
 }

--- a/bridge/api/app/app.go
+++ b/bridge/api/app/app.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"tractor.dev/apptron/bridge/api/menu"
-	"tractor.dev/apptron/bridge/resource"
 )
 
 var Module *module
@@ -21,11 +20,7 @@ type Options struct {
 }
 
 func (m *module) Menu() *menu.Menu {
-	return menu.GetMenu()
-}
-
-func (m *module) SetMenu(handle resource.Handle) error {
-	return menu.Set(handle)
+	return menu.Main()
 }
 
 func (m *module) NewIndicator(icon []byte, items []menu.Item) error {

--- a/bridge/api/app/app.go
+++ b/bridge/api/app/app.go
@@ -19,17 +19,16 @@ type Options struct {
 	Accessory  bool // app should not be task switchable
 }
 
+func SetMenu(m *menu.Menu) error {
+	return menu.SetMenu(m)
+}
+
 func (m *module) Menu() *menu.Menu {
-	return Menu()
+	return menu.GetMenu()
 }
 
 func (m *module) SetMenu(handle resource.Handle) error {
-	mm, err := menu.Get(handle)
-	if err != nil {
-		return err
-	}
-	SetMenu(mm)
-	return nil
+	return menu.Set(handle)
 }
 
 func (m *module) NewIndicator(icon []byte, items []menu.Item) error {

--- a/bridge/api/app/app_darwin.go
+++ b/bridge/api/app/app_darwin.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	mainMenu *menu.Menu
-	app      cocoa.NSApplication
+	app cocoa.NSApplication
 )
 
 func init() {
@@ -19,13 +18,16 @@ func init() {
 }
 
 func Menu() *menu.Menu {
-	return mainMenu
+	return menu.GetMenu()
 }
 
 func SetMenu(menu *menu.Menu) error {
 	app.SetMainMenu(menu.NSMenu)
-	mainMenu = menu
-	return nil
+	menu.SetMenu(menu)
+}
+
+func (m *module) SetMenu(handle resource.Handle) error {
+	return menu.SetMenuHandle(handle)
 }
 
 func NewIndicator(icon []byte, items []menu.Item) {

--- a/bridge/api/app/app_darwin.go
+++ b/bridge/api/app/app_darwin.go
@@ -17,17 +17,9 @@ func init() {
 	app = cocoa.NSApp()
 }
 
-func Menu() *menu.Menu {
-	return menu.GetMenu()
-}
-
-func SetMenu(menu *menu.Menu) error {
-	app.SetMainMenu(menu.NSMenu)
-	menu.SetMenu(menu)
-}
-
-func (m *module) SetMenu(handle resource.Handle) error {
-	return menu.SetMenuHandle(handle)
+func SetMenu(m *menu.Menu) error {
+	app.SetMainMenu(m.NSMenu)
+	return menu.SetMenu(m)
 }
 
 func NewIndicator(icon []byte, items []menu.Item) {
@@ -63,8 +55,11 @@ func Run(options Options) error {
 		return !options.Agent
 	})
 	DelegateClass.AddMethod("applicationWillFinishLaunching:", func(notification objc.Object) {
+		mainMenu := menu.GetMenu()
 		if mainMenu == nil {
-			mainMenu = menu.New([]menu.Item{})
+			menu.SetMenu(menu.New([]menu.Item{}))
+			mainMenu = menu.GetMenu()
+			app.SetMainMenu(mainMenu.NSMenu)
 		}
 		if options.Accessory {
 			app.SetActivationPolicy(cocoa.NSApplicationActivationPolicyAccessory)

--- a/bridge/api/app/app_darwin.go
+++ b/bridge/api/app/app_darwin.go
@@ -81,6 +81,10 @@ func Run(options Options) error {
 
 	app.SetDelegate(objc.Get("AppDelegate").Alloc().Init())
 
+	if options.DisableAutoSave != true {
+		setupWindowRestoreListener(options.Identifier)
+	}
+
 	platform.Start()
 	return nil
 }

--- a/bridge/api/app/app_darwin.go
+++ b/bridge/api/app/app_darwin.go
@@ -19,7 +19,7 @@ func init() {
 
 func SetMenu(m *menu.Menu) error {
 	app.SetMainMenu(m.NSMenu)
-	return menu.SetMenu(m)
+	return menu.SetMain(m)
 }
 
 func NewIndicator(icon []byte, items []menu.Item) {
@@ -55,10 +55,10 @@ func Run(options Options) error {
 		return !options.Agent
 	})
 	DelegateClass.AddMethod("applicationWillFinishLaunching:", func(notification objc.Object) {
-		mainMenu := menu.GetMenu()
+		mainMenu := menu.Main()
 		if mainMenu == nil {
-			menu.SetMenu(menu.New([]menu.Item{}))
-			mainMenu = menu.GetMenu()
+			menu.SetMain(menu.New([]menu.Item{}))
+			mainMenu = menu.Main()
 			app.SetMainMenu(mainMenu.NSMenu)
 		}
 		if options.Accessory {

--- a/bridge/api/app/app_linux.go
+++ b/bridge/api/app/app_linux.go
@@ -66,6 +66,10 @@ func NewIndicator(icon []byte, items []menu.Item) {
 }
 
 func Run(options Options) error {
+  if options.DisableAutoSave != true {
+    setupWindowRestoreListener(options.Identifier)
+  }
+
   // NOTE(nick): MacOS-style window behavior
   if options.Agent == false {
     var windowCount int64

--- a/bridge/api/app/app_windows.go
+++ b/bridge/api/app/app_windows.go
@@ -52,7 +52,7 @@ func NewIndicator(icon []byte, items []menu.Item) {
 }
 
 func Run(options Options) error {
-	if options.DisableAutoSave != false {
+	if options.DisableAutoSave != true {
 		setupWindowRestoreListener(options.Identifier)
 	}
 

--- a/bridge/api/app/app_windows.go
+++ b/bridge/api/app/app_windows.go
@@ -35,6 +35,10 @@ func init() {
 	}
 }
 
+func SetMenu(m *menu.Menu) error {
+	return menu.SetMenu(m)
+}
+
 func NewIndicator(icon []byte, items []menu.Item) {
 	menu := menu.New(items)
 	onClick := func(id int32) {

--- a/bridge/api/app/app_windows.go
+++ b/bridge/api/app/app_windows.go
@@ -48,11 +48,15 @@ func NewIndicator(icon []byte, items []menu.Item) {
 }
 
 func Run(options Options) error {
+	if options.DisableAutoSave != false {
+		setupWindowRestoreListener(options.Identifier)
+	}
+
 	// NOTE(nick): MacOS-style window behavior
 	if options.Agent == false {
 		var windowCount int64
 
-		event.Listen("__APPTRON_Platform_listener__", func(e event.Event) error {
+		event.Listen("__APPTRON_Platform_listener2__", func(e event.Event) error {
 			if e.Type == event.Created {
 				atomic.AddInt64(&windowCount, 1)
 			}

--- a/bridge/api/app/app_windows.go
+++ b/bridge/api/app/app_windows.go
@@ -9,10 +9,6 @@ import (
 	"tractor.dev/apptron/bridge/platform/win32"
 )
 
-var (
-	mainMenu *menu.Menu
-)
-
 func init() {
 	// @see https://github.com/glfw/glfw/blob/master/src/win32_init.c#L692
 
@@ -39,15 +35,6 @@ func init() {
 	}
 }
 
-func Menu() *menu.Menu {
-	return mainMenu
-}
-
-func SetMenu(menu *menu.Menu) error {
-	mainMenu = menu
-	return nil
-}
-
 func NewIndicator(icon []byte, items []menu.Item) {
 	menu := menu.New(items)
 	onClick := func(id int32) {
@@ -72,7 +59,7 @@ func Run(options Options) error {
 
 			if e.Type == event.Destroyed {
 				if atomic.AddInt64(&windowCount, -1) == 0 {
-					platform.Terminate()
+					platform.Terminate(true)
 				}
 			}
 

--- a/bridge/api/app/app_windows.go
+++ b/bridge/api/app/app_windows.go
@@ -60,7 +60,7 @@ func Run(options Options) error {
 	if options.Agent == false {
 		var windowCount int64
 
-		event.Listen("__APPTRON_Platform_listener2__", func(e event.Event) error {
+		event.Listen("__APPTRON_Platform_listener__", func(e event.Event) error {
 			if e.Type == event.Created {
 				atomic.AddInt64(&windowCount, 1)
 			}

--- a/bridge/api/app/app_windows.go
+++ b/bridge/api/app/app_windows.go
@@ -36,7 +36,7 @@ func init() {
 }
 
 func SetMenu(m *menu.Menu) error {
-	return menu.SetMenu(m)
+	return menu.SetMain(m)
 }
 
 func NewIndicator(icon []byte, items []menu.Item) {

--- a/bridge/api/app/shared.go
+++ b/bridge/api/app/shared.go
@@ -43,6 +43,8 @@ func SaveWindowSettings(win *window.Window, identifier string, key string) bool 
 
 	settings := WindowSettings{Key: key, Position: win.GetOuterPosition(), Size: win.GetInnerSize()}
 
+	log.Println("SAVE settings", settings)
+
 	data, _ := json.MarshalIndent(settings, "", " ")
 
 	fname := "window_" + key + ".json"
@@ -82,8 +84,12 @@ func RestoreWindowSettings(win *window.Window, identifier string, key string) bo
 		return false
 	}
 
-	win.SetPosition(settings.Position)
+	log.Println("LOAD settings", settings)
+
+	// @Incomplete @Robustness: there's a bug where if you set the position before the size on macos
+	// the position will be wrong because the position uses the frame rect size implicitly
 	win.SetSize(settings.Size)
+	win.SetPosition(settings.Position)
 
 	return true
 }
@@ -98,7 +104,7 @@ func setupWindowRestoreListener(identifier string) {
 		}
 
 		// TODO: event.Close is not fired on MacOS
-		if e.Type == event.Close || e.Type == event.Destroyed {
+		if e.Type == event.Destroyed {
 			win, _ := window.Get(e.Window)
 			if win != nil && len(win.ID) > 0 {
 				SaveWindowSettings(win, identifier, win.ID)

--- a/bridge/api/app/shared.go
+++ b/bridge/api/app/shared.go
@@ -1,0 +1,109 @@
+package app
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"tractor.dev/apptron/bridge/api/window"
+	"tractor.dev/apptron/bridge/event"
+	"tractor.dev/apptron/bridge/misc"
+)
+
+type WindowSettings struct {
+	Key      string
+	Position misc.Position
+	Size     misc.Size
+}
+
+func SaveWindowSettings(win *window.Window, identifier string, key string) bool {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		log.Println("[WindowSettings] Failed to get user cache dir")
+		return false
+	}
+
+	dirpath := filepath.Join(dir, identifier)
+
+	// create directory if not exists
+	if _, err = os.Stat(dirpath); os.IsNotExist(err) {
+		err = os.Mkdir(dirpath, os.ModePerm)
+		if err != nil {
+			log.Println("[WindowSettings] Failed to create save directory:", dirpath, err)
+			return false
+		}
+	}
+
+	if _, err := os.Stat(dirpath); os.IsNotExist(err) {
+		log.Println("[WindowSettings] Directory doesn't exist:", dirpath, err)
+		return false
+	}
+
+	settings := WindowSettings{Key: key, Position: win.GetOuterPosition(), Size: win.GetInnerSize()}
+
+	data, _ := json.MarshalIndent(settings, "", " ")
+
+	fname := "window_" + key + ".json"
+	path := filepath.Join(dirpath, fname)
+
+	err = ioutil.WriteFile(path, data, 0644)
+	if err != nil {
+		log.Println("[WindowSettings] Did not write file:", path, err)
+		return false
+	}
+
+	return true
+}
+
+func RestoreWindowSettings(win *window.Window, identifier string, key string) bool {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		log.Println("[WindowSettings] Failed to get user cache dir")
+		return false
+	}
+
+	dirpath := filepath.Join(dir, identifier)
+
+	fname := "window_" + key + ".json"
+	path := filepath.Join(dirpath, fname)
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Println("[WindowSettings] Failed to read file:", path, err)
+		return false
+	}
+
+	settings := WindowSettings{}
+	err = json.Unmarshal(content, &settings)
+	if err != nil {
+		log.Println("[WindowSettings] Failed to parse JSON:", path, err)
+		return false
+	}
+
+	win.SetPosition(settings.Position)
+	win.SetSize(settings.Size)
+
+	return true
+}
+
+func setupWindowRestoreListener(identifier string) {
+	event.Listen("__APPTRON_Platform_listener1__", func(e event.Event) error {
+		if e.Type == event.Created {
+			win, _ := window.Get(e.Window)
+			if win != nil && len(win.ID) > 0 {
+				RestoreWindowSettings(win, identifier, win.ID)
+			}
+		}
+
+		if e.Type == event.Close {
+			win, _ := window.Get(e.Window)
+			if win != nil && len(win.ID) > 0 {
+				SaveWindowSettings(win, identifier, win.ID)
+			}
+		}
+
+		return nil
+	})
+}

--- a/bridge/api/app/shared.go
+++ b/bridge/api/app/shared.go
@@ -89,7 +89,7 @@ func RestoreWindowSettings(win *window.Window, identifier string, key string) bo
 }
 
 func setupWindowRestoreListener(identifier string) {
-	event.Listen("__APPTRON_Platform_listener1__", func(e event.Event) error {
+	event.Listen("__APPTRON_Platform_listener__WindowRestore__", func(e event.Event) error {
 		if e.Type == event.Created {
 			win, _ := window.Get(e.Window)
 			if win != nil && len(win.ID) > 0 {

--- a/bridge/api/app/shared.go
+++ b/bridge/api/app/shared.go
@@ -93,15 +93,14 @@ func setupWindowRestoreListener(identifier string) {
 		if e.Type == event.Created {
 			win, _ := window.Get(e.Window)
 			if win != nil && len(win.ID) > 0 {
-				log.Println("win ID", win.ID)
 				RestoreWindowSettings(win, identifier, win.ID)
 			}
 		}
 
-		if e.Type == event.Close {
+		// TODO: event.Close is not fired on MacOS
+		if e.Type == event.Close || e.Type == event.Destroyed {
 			win, _ := window.Get(e.Window)
 			if win != nil && len(win.ID) > 0 {
-				log.Println("win ID", win.ID)
 				SaveWindowSettings(win, identifier, win.ID)
 			}
 		}

--- a/bridge/api/app/shared.go
+++ b/bridge/api/app/shared.go
@@ -93,6 +93,7 @@ func setupWindowRestoreListener(identifier string) {
 		if e.Type == event.Created {
 			win, _ := window.Get(e.Window)
 			if win != nil && len(win.ID) > 0 {
+				log.Println("win ID", win.ID)
 				RestoreWindowSettings(win, identifier, win.ID)
 			}
 		}
@@ -100,6 +101,7 @@ func setupWindowRestoreListener(identifier string) {
 		if e.Type == event.Close {
 			win, _ := window.Get(e.Window)
 			if win != nil && len(win.ID) > 0 {
+				log.Println("win ID", win.ID)
 				SaveWindowSettings(win, identifier, win.ID)
 			}
 		}

--- a/bridge/api/menu/menu.go
+++ b/bridge/api/menu/menu.go
@@ -17,21 +17,12 @@ var (
 	mainMenu *Menu
 )
 
-func GetMenu() *Menu {
+func Main() *Menu {
 	return mainMenu
 }
 
-func SetMenu(menu *Menu) error {
+func SetMain(menu *Menu) error {
 	mainMenu = menu
-	return nil
-}
-
-func Set(handle resource.Handle) error {
-	mm, err := Get(handle)
-	if err != nil {
-		return err
-	}
-	SetMenu(mm)
 	return nil
 }
 

--- a/bridge/api/menu/menu.go
+++ b/bridge/api/menu/menu.go
@@ -13,6 +13,15 @@ func init() {
 	Module = &module{}
 }
 
+func Set(handle resource.Handle) error {
+	mm, err := Get(handle)
+	if err != nil {
+		return err
+	}
+	SetMenu(mm)
+	return nil
+}
+
 func Get(handle resource.Handle) (*Menu, error) {
 	v, err := resource.Lookup(handle)
 	if err != nil {

--- a/bridge/api/menu/menu.go
+++ b/bridge/api/menu/menu.go
@@ -13,6 +13,19 @@ func init() {
 	Module = &module{}
 }
 
+var (
+	mainMenu *Menu
+)
+
+func GetMenu() *Menu {
+	return mainMenu
+}
+
+func SetMenu(menu *Menu) error {
+	mainMenu = menu
+	return nil
+}
+
 func Set(handle resource.Handle) error {
 	mm, err := Get(handle)
 	if err != nil {

--- a/bridge/api/menu/menu_windows.go
+++ b/bridge/api/menu/menu_windows.go
@@ -5,6 +5,19 @@ import (
 	"tractor.dev/apptron/bridge/resource"
 )
 
+var (
+	mainMenu *Menu
+)
+
+func GetMenu() *Menu {
+	return mainMenu
+}
+
+func SetMenu(menu *Menu) error {
+	mainMenu = menu
+	return nil
+}
+
 type Menu struct {
 	menu
 

--- a/bridge/api/menu/menu_windows.go
+++ b/bridge/api/menu/menu_windows.go
@@ -5,19 +5,6 @@ import (
 	"tractor.dev/apptron/bridge/resource"
 )
 
-var (
-	mainMenu *Menu
-)
-
-func GetMenu() *Menu {
-	return mainMenu
-}
-
-func SetMenu(menu *Menu) error {
-	mainMenu = menu
-	return nil
-}
-
 type Menu struct {
 	menu
 

--- a/bridge/api/window/window.go
+++ b/bridge/api/window/window.go
@@ -64,6 +64,7 @@ type Options struct {
 	Script      string
 	ChromeURL   string
 	ChromeHTML  string // TODO
+	ID          string
 }
 
 type Size = misc.Size

--- a/bridge/api/window/window_darwin.go
+++ b/bridge/api/window/window_darwin.go
@@ -307,6 +307,13 @@ func New(options Options) (*Window, error) {
 	}
 	resource.Retain(win.Handle, win)
 
+	event.Emit(event.Event{
+		Type:     event.Created,
+		Window:   win.Handle,
+		Size:     win.GetInnerSize(),
+		Position: win.GetOuterPosition(),
+	})
+
 	return win, nil
 }
 

--- a/bridge/api/window/window_darwin.go
+++ b/bridge/api/window/window_darwin.go
@@ -48,6 +48,8 @@ type Window struct {
 	window
 	moveOffset     mac.NSPoint
 	cocoa.NSWindow `json:"-"`
+
+	ID string
 }
 
 var ptrLookup sync.Map
@@ -301,6 +303,7 @@ func New(options Options) (*Window, error) {
 			Handle: resource.NewHandle(),
 		},
 		NSWindow: nswin,
+		ID:       options.ID,
 	}
 	resource.Retain(win.Handle, win)
 
@@ -409,4 +412,9 @@ func (w *Window) GetOuterSize() Size {
 		Width:  frame.Size.Width,
 		Height: frame.Size.Height,
 	}
+}
+
+func (w *Window) GetInnerSize() Size {
+	// TODO(nick): adjust window rect
+	return w.GetOuterSize()
 }

--- a/bridge/api/window/window_darwin.go
+++ b/bridge/api/window/window_darwin.go
@@ -397,6 +397,7 @@ func (w *Window) SetPosition(position Position) {
 	// NOTE(nick): Y is inverted on MacOS
 	position.Y = screenRect.Size.Height - position.Y
 
+	// @Robustness: this implicitly relies on the frame size now that Y is inverted
 	w.SetFrameTopLeftPoint_(mac.Point(position.X, position.Y))
 }
 

--- a/bridge/api/window/window_linux.go
+++ b/bridge/api/window/window_linux.go
@@ -19,6 +19,8 @@ type Window struct {
 
   prevPosition linux.Position
   prevSize     linux.Size
+
+  ID string
 }
 
 var ptrLookup sync.Map
@@ -109,6 +111,7 @@ func New(options Options) (*Window, error) {
     window: window{
       Handle: resource.NewHandle(),
     },
+    ID: options.ID,
   }
   resource.Retain(win.Handle, win)
 
@@ -296,4 +299,9 @@ func (w *Window) GetOuterSize() Size {
     Width:  float64(size.Width),
     Height: float64(size.Height),
   }
+}
+
+func (w *Window) GetInnerSize() Size {
+  // TODO(nick): implement me
+  return w.GetOuterSize()
 }

--- a/bridge/api/window/window_linux.go
+++ b/bridge/api/window/window_linux.go
@@ -212,8 +212,10 @@ func New(options Options) (*Window, error) {
   win.callbackId = callbackId
 
   event.Emit(event.Event{
-    Type:   event.Created,
-    Window: win.Handle,
+    Type:     event.Created,
+    Window:   win.Handle,
+    Size:     win.GetInnerSize(),
+    Position: win.GetOuterPosition(),
   })
 
   return win, nil

--- a/bridge/api/window/window_windows.go
+++ b/bridge/api/window/window_windows.go
@@ -26,6 +26,8 @@ type Window struct {
 	hasMenu       BOOL
 	scale         Size
 	isTransparent bool
+
+	ID string
 }
 
 func init() {
@@ -41,8 +43,10 @@ func windowCallback(hwnd HWND, message uint32, wParam WPARAM, lParam LPARAM) LRE
 	switch message {
 	case WM_CLOSE:
 		event.Emit(event.Event{
-			Type:   event.Close,
-			Window: w.Handle,
+			Type:     event.Close,
+			Window:   w.Handle,
+			Size:     w.GetInnerSize(),
+			Position: w.GetOuterPosition(),
 		})
 
 		// @Incomplete: should this still close the window or should that be up to the user?
@@ -51,20 +55,26 @@ func windowCallback(hwnd HWND, message uint32, wParam WPARAM, lParam LPARAM) LRE
 
 	case WM_DESTROY:
 		event.Emit(event.Event{
-			Type:   event.Destroyed,
-			Window: w.Handle,
+			Type:     event.Destroyed,
+			Window:   w.Handle,
+			Size:     w.GetInnerSize(),
+			Position: w.GetOuterPosition(),
 		})
 
 	case WM_SETFOCUS:
 		event.Emit(event.Event{
-			Type:   event.Focused,
-			Window: w.Handle,
+			Type:     event.Focused,
+			Window:   w.Handle,
+			Size:     w.GetInnerSize(),
+			Position: w.GetOuterPosition(),
 		})
 
 	case WM_KILLFOCUS:
 		event.Emit(event.Event{
-			Type:   event.Blurred,
-			Window: w.Handle,
+			Type:     event.Blurred,
+			Window:   w.Handle,
+			Size:     w.GetInnerSize(),
+			Position: w.GetOuterPosition(),
 		})
 
 	case WM_SIZE:
@@ -73,9 +83,10 @@ func windowCallback(hwnd HWND, message uint32, wParam WPARAM, lParam LPARAM) LRE
 		}
 
 		event.Emit(event.Event{
-			Type:   event.Resized,
-			Window: w.Handle,
-			Size:   w.GetInnerSize(),
+			Type:     event.Resized,
+			Window:   w.Handle,
+			Size:     w.GetInnerSize(),
+			Position: w.GetOuterPosition(),
 		})
 
 	case WM_ACTIVATE:
@@ -111,6 +122,7 @@ func windowCallback(hwnd HWND, message uint32, wParam WPARAM, lParam LPARAM) LRE
 		event.Emit(event.Event{
 			Type:     event.Moved,
 			Window:   w.Handle,
+			Size:     w.GetInnerSize(),
 			Position: w.GetOuterPosition(),
 		})
 
@@ -365,8 +377,10 @@ func New(options Options) (*Window, error) {
 	}
 
 	event.Emit(event.Event{
-		Type:   event.Created,
-		Window: win.Handle,
+		Type:     event.Created,
+		Window:   win.Handle,
+		Size:     win.GetInnerSize(),
+		Position: win.GetOuterPosition(),
 	})
 
 	return win, nil

--- a/bridge/api/window/window_windows.go
+++ b/bridge/api/window/window_windows.go
@@ -234,7 +234,7 @@ func New(options Options) (*Window, error) {
 	}
 
 	var hasMenu BOOL = FALSE
-	m := menu.GetMenu()
+	m := menu.Main()
 	if m != nil {
 		SetMenu(hwnd, m.Menu)
 		hasMenu = TRUE

--- a/bridge/api/window/window_windows.go
+++ b/bridge/api/window/window_windows.go
@@ -43,10 +43,8 @@ func windowCallback(hwnd HWND, message uint32, wParam WPARAM, lParam LPARAM) LRE
 	switch message {
 	case WM_CLOSE:
 		event.Emit(event.Event{
-			Type:     event.Close,
-			Window:   w.Handle,
-			Size:     w.GetInnerSize(),
-			Position: w.GetOuterPosition(),
+			Type:   event.Close,
+			Window: w.Handle,
 		})
 
 		// @Incomplete: should this still close the window or should that be up to the user?
@@ -55,26 +53,20 @@ func windowCallback(hwnd HWND, message uint32, wParam WPARAM, lParam LPARAM) LRE
 
 	case WM_DESTROY:
 		event.Emit(event.Event{
-			Type:     event.Destroyed,
-			Window:   w.Handle,
-			Size:     w.GetInnerSize(),
-			Position: w.GetOuterPosition(),
+			Type:   event.Destroyed,
+			Window: w.Handle,
 		})
 
 	case WM_SETFOCUS:
 		event.Emit(event.Event{
-			Type:     event.Focused,
-			Window:   w.Handle,
-			Size:     w.GetInnerSize(),
-			Position: w.GetOuterPosition(),
+			Type:   event.Focused,
+			Window: w.Handle,
 		})
 
 	case WM_KILLFOCUS:
 		event.Emit(event.Event{
-			Type:     event.Blurred,
-			Window:   w.Handle,
-			Size:     w.GetInnerSize(),
-			Position: w.GetOuterPosition(),
+			Type:   event.Blurred,
+			Window: w.Handle,
 		})
 
 	case WM_SIZE:
@@ -83,10 +75,9 @@ func windowCallback(hwnd HWND, message uint32, wParam WPARAM, lParam LPARAM) LRE
 		}
 
 		event.Emit(event.Event{
-			Type:     event.Resized,
-			Window:   w.Handle,
-			Size:     w.GetInnerSize(),
-			Position: w.GetOuterPosition(),
+			Type:   event.Resized,
+			Window: w.Handle,
+			Size:   w.GetInnerSize(),
 		})
 
 	case WM_ACTIVATE:
@@ -122,7 +113,6 @@ func windowCallback(hwnd HWND, message uint32, wParam WPARAM, lParam LPARAM) LRE
 		event.Emit(event.Event{
 			Type:     event.Moved,
 			Window:   w.Handle,
-			Size:     w.GetInnerSize(),
 			Position: w.GetOuterPosition(),
 		})
 

--- a/bridge/api/window/window_windows.go
+++ b/bridge/api/window/window_windows.go
@@ -326,6 +326,7 @@ func New(options Options) (*Window, error) {
 	win.minSize = POINT{X: LONG(options.MinSize.Width), Y: LONG(options.MinSize.Height)}
 	win.maxSize = POINT{X: LONG(options.MaxSize.Width), Y: LONG(options.MaxSize.Height)}
 	win.isTransparent = options.Transparent
+	win.ID = options.ID
 
 	chromium.MessageCallback = win.messageCallback
 	//chromium.Eval("window.chrome.webview.postMessage('Hello, sir!');")

--- a/bridge/api/window/window_windows.go
+++ b/bridge/api/window/window_windows.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/jchv/go-webview2/pkg/edge"
 
-	"tractor.dev/apptron/bridge/api/app"
+	"tractor.dev/apptron/bridge/api/menu"
 	"tractor.dev/apptron/bridge/event"
 	. "tractor.dev/apptron/bridge/platform/win32"
 	"tractor.dev/apptron/bridge/resource"
@@ -232,9 +232,9 @@ func New(options Options) (*Window, error) {
 	}
 
 	var hasMenu BOOL = FALSE
-	menu := app.Menu()
-	if menu != nil {
-		SetMenu(hwnd, menu.Menu)
+	m := menu.GetMenu()
+	if m != nil {
+		SetMenu(hwnd, m.Menu)
 		hasMenu = TRUE
 	}
 

--- a/bridge/platform/main_windows.go
+++ b/bridge/platform/main_windows.go
@@ -38,6 +38,6 @@ loop:
 	win32.ExitProcess(0)
 }
 
-func Terminate() {
+func Terminate(_dispatch bool) {
 	shouldQuit = true
 }

--- a/bridge/platform/platform.go
+++ b/bridge/platform/platform.go
@@ -1,6 +1,8 @@
 package platform
 
-import "sync"
+import (
+	"sync"
+)
 
 var (
 	isRunning bool

--- a/client/app.go
+++ b/client/app.go
@@ -11,9 +11,10 @@ type AppModule struct {
 }
 
 type AppOptions struct {
-	Identifier string
-	Agent      bool
-	Accessory  bool
+	Identifier      string
+	Agent           bool
+	Accessory       bool
+	DisableAutoSave bool
 }
 
 // Run

--- a/client/window.go
+++ b/client/window.go
@@ -39,6 +39,8 @@ type WindowOptions struct {
 	HTML        string
 	Script      string
 	ChromeURL   string
+	ChromeHTML  string // TODO
+	ID          string
 }
 
 type WindowModule struct {

--- a/cmd/debug/main_cmd.go
+++ b/cmd/debug/main_cmd.go
@@ -41,6 +41,7 @@ func main() {
 
 	options := client.WindowOptions{
 		Title: "Demo window",
+		ID:    "demo",
 		// NOTE(nick): resizing a transparent window on MacOS seems really slow?
 		Transparent: true,
 		Frameless:   false,
@@ -67,7 +68,7 @@ func main() {
 		panic(err)
 	}
 
-	w1.SetPosition(ctx, client.Position{X: 100, Y: 100})
+	//w1.SetPosition(ctx, client.Position{X: 100, Y: 100})
 
 	fmt.Println("[main] window", w1)
 

--- a/cmd/debug/main_pkg.go
+++ b/cmd/debug/main_pkg.go
@@ -127,6 +127,7 @@ func run() {
 
 	options := window.Options{
 		Title:       "Demo window",
+		ID:          "w1",
 		Transparent: true,
 		Frameless:   false,
 		Visible:     true,
@@ -159,9 +160,6 @@ func run() {
 
 		w1.SetTitle("Hello, Sailor!")
 		fmt.Println("[main] window position", w1.GetOuterPosition())
-
-		app.RestoreWindowSettings(w1, "com.progrium.Apptron", "w1")
-		app.SaveWindowSettings(w1, "com.progrium.Apptron", "w1")
 
 		//w1.SetMinSize(window.Size{Width: 100, Height: 100})
 	})

--- a/cmd/debug/main_pkg.go
+++ b/cmd/debug/main_pkg.go
@@ -7,11 +7,6 @@ import (
 	"log"
 	"runtime"
 
-	"encoding/json"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
 	"tractor.dev/apptron/bridge/api/app"
 	"tractor.dev/apptron/bridge/api/menu"
 	"tractor.dev/apptron/bridge/api/shell"
@@ -21,100 +16,6 @@ import (
 	"tractor.dev/apptron/bridge/misc"
 	"tractor.dev/apptron/bridge/platform"
 )
-
-type WindowSettings struct {
-	Key      string
-	Position misc.Position
-	Size     misc.Size
-}
-
-/*
-func LoadAllWindowSettings() []WindowSettings {
-	identifier := "com.progrium.Apptron"
-
-	dir, err := os.UserCacheDir()
-	if err != nil {
-		log.Println("[WindowSettings] Failed to get user cache dir")
-		return []WindowSettings{}
-	}
-
-	path := filepath.Join(dir, identifier, "windows.json")
-}
-*/
-
-func SaveWindowSettings(win *window.Window, key string) bool {
-	identifier := "com.progrium.Apptron"
-
-	dir, err := os.UserCacheDir()
-	if err != nil {
-		log.Println("[WindowSettings] Failed to get user cache dir")
-		return false
-	}
-
-	dirpath := filepath.Join(dir, identifier)
-
-	// create directory if not exists
-	if _, err = os.Stat(dirpath); os.IsNotExist(err) {
-		err = os.Mkdir(dirpath, os.ModePerm)
-		if err != nil {
-			log.Println("[WindowSettings] Failed to create save directory:", dirpath, err)
-			return false
-		}
-	}
-
-	if _, err := os.Stat(dirpath); os.IsNotExist(err) {
-		log.Println("[WindowSettings] Directory doesn't exist:", dirpath, err)
-		return false
-	}
-
-	settings := WindowSettings{Key: key, Position: win.GetOuterPosition(), Size: win.GetInnerSize()}
-
-	data, _ := json.MarshalIndent(settings, "", " ")
-
-	fname := "window_" + key + ".json"
-	path := filepath.Join(dirpath, fname)
-
-	err = ioutil.WriteFile(path, data, 0644)
-	if err != nil {
-		log.Println("[WindowSettings] Did not write file:", path, err)
-		return false
-	}
-
-	return true
-}
-
-func RestoreWindowSettings(win *window.Window, key string) bool {
-	identifier := "com.progrium.Apptron"
-
-	dir, err := os.UserCacheDir()
-	if err != nil {
-		log.Println("[WindowSettings] Failed to get user cache dir")
-		return false
-	}
-
-	dirpath := filepath.Join(dir, identifier)
-
-	fname := "window_" + key + ".json"
-	path := filepath.Join(dirpath, fname)
-
-	content, err := ioutil.ReadFile(path)
-	if err != nil {
-		log.Println("[WindowSettings] Failed to read file:", path, err)
-		return false
-	}
-
-	settings := WindowSettings{}
-	err = json.Unmarshal(content, &settings)
-	if err != nil {
-		log.Println("[WindowSettings] Failed to parse JSON:", path, err)
-		return false
-	}
-
-	win.SetPosition(settings.Position)
-	win.SetSize(settings.Size)
-
-	return true
-}
 
 const QUIT_ID = 1
 
@@ -259,8 +160,8 @@ func run() {
 		w1.SetTitle("Hello, Sailor!")
 		fmt.Println("[main] window position", w1.GetOuterPosition())
 
-		RestoreWindowSettings(w1, "w1")
-		SaveWindowSettings(w1, "w1")
+		app.RestoreWindowSettings(w1, "com.progrium.Apptron", "w1")
+		app.SaveWindowSettings(w1, "com.progrium.Apptron", "w1")
 
 		//w1.SetMinSize(window.Size{Width: 100, Height: 100})
 	})

--- a/cmd/debug/main_pkg.go
+++ b/cmd/debug/main_pkg.go
@@ -7,6 +7,11 @@ import (
 	"log"
 	"runtime"
 
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	"tractor.dev/apptron/bridge/api/app"
 	"tractor.dev/apptron/bridge/api/menu"
 	"tractor.dev/apptron/bridge/api/shell"
@@ -16,6 +21,100 @@ import (
 	"tractor.dev/apptron/bridge/misc"
 	"tractor.dev/apptron/bridge/platform"
 )
+
+type WindowSettings struct {
+	Key      string
+	Position misc.Position
+	Size     misc.Size
+}
+
+/*
+func LoadAllWindowSettings() []WindowSettings {
+	identifier := "com.progrium.Apptron"
+
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		log.Println("[WindowSettings] Failed to get user cache dir")
+		return []WindowSettings{}
+	}
+
+	path := filepath.Join(dir, identifier, "windows.json")
+}
+*/
+
+func SaveWindowSettings(win *window.Window, key string) bool {
+	identifier := "com.progrium.Apptron"
+
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		log.Println("[WindowSettings] Failed to get user cache dir")
+		return false
+	}
+
+	dirpath := filepath.Join(dir, identifier)
+
+	// create directory if not exists
+	if _, err = os.Stat(dirpath); os.IsNotExist(err) {
+		err = os.Mkdir(dirpath, os.ModePerm)
+		if err != nil {
+			log.Println("[WindowSettings] Failed to create save directory:", dirpath, err)
+			return false
+		}
+	}
+
+	if _, err := os.Stat(dirpath); os.IsNotExist(err) {
+		log.Println("[WindowSettings] Directory doesn't exist:", dirpath, err)
+		return false
+	}
+
+	settings := WindowSettings{Key: key, Position: win.GetOuterPosition(), Size: win.GetInnerSize()}
+
+	data, _ := json.MarshalIndent(settings, "", " ")
+
+	fname := "window_" + key + ".json"
+	path := filepath.Join(dirpath, fname)
+
+	err = ioutil.WriteFile(path, data, 0644)
+	if err != nil {
+		log.Println("[WindowSettings] Did not write file:", path, err)
+		return false
+	}
+
+	return true
+}
+
+func RestoreWindowSettings(win *window.Window, key string) bool {
+	identifier := "com.progrium.Apptron"
+
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		log.Println("[WindowSettings] Failed to get user cache dir")
+		return false
+	}
+
+	dirpath := filepath.Join(dir, identifier)
+
+	fname := "window_" + key + ".json"
+	path := filepath.Join(dirpath, fname)
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Println("[WindowSettings] Failed to read file:", path, err)
+		return false
+	}
+
+	settings := WindowSettings{}
+	err = json.Unmarshal(content, &settings)
+	if err != nil {
+		log.Println("[WindowSettings] Failed to parse JSON:", path, err)
+		return false
+	}
+
+	win.SetPosition(settings.Position)
+	win.SetSize(settings.Size)
+
+	return true
+}
 
 const QUIT_ID = 1
 
@@ -131,7 +230,8 @@ func run() {
 		Frameless:   false,
 		Visible:     true,
 		Resizable:   true,
-		Center:      true,
+		Center:      false,
+		Size:        misc.Size{Width: 400, Height: 320},
 		Icon:        iconData,
 		HTML: `
 			<!doctype html>
@@ -158,6 +258,9 @@ func run() {
 
 		w1.SetTitle("Hello, Sailor!")
 		fmt.Println("[main] window position", w1.GetOuterPosition())
+
+		RestoreWindowSettings(w1, "w1")
+		SaveWindowSettings(w1, "w1")
 
 		//w1.SetMinSize(window.Size{Width: 100, Height: 100})
 	})


### PR DESCRIPTION
This implements auto saving / loading window positions. This feature will be enabled for any window as long as `app.Options.DisableAutoSave` is not `true` and the window has an `ID`. We only save / load the window on `event.Closed` and `event.Created` respectively.

It seems probably best to keep this behavior the same across all 3 OSes even though MacOS has it's own API for this.

My implementation creates a separate file per window rather than one `windows.json` because otherwise you'd have to load the file before you could save a new window entry, and maybe multiple windows could be closed at once so one of those reads could fail or have stale data?

I also wasn't sure of a better thing than just to put an `ID` field on each of the OS-specific windows. This seems fine, but wasn't sure if there was a more platform-agnostic way to express this because the shared `window` is a private field

Final part of #57