### PR TITLE
Battery API

### DIFF
--- a/bridge/api/app/shared.go
+++ b/bridge/api/app/shared.go
@@ -43,8 +43,6 @@ func SaveWindowSettings(win *window.Window, identifier string, key string) bool 
 
 	settings := WindowSettings{Key: key, Position: win.GetOuterPosition(), Size: win.GetInnerSize()}
 
-	log.Println("SAVE settings", settings)
-
 	data, _ := json.MarshalIndent(settings, "", " ")
 
 	fname := "window_" + key + ".json"
@@ -83,8 +81,6 @@ func RestoreWindowSettings(win *window.Window, identifier string, key string) bo
 		log.Println("[WindowSettings] Failed to parse JSON:", path, err)
 		return false
 	}
-
-	log.Println("LOAD settings", settings)
 
 	// @Incomplete @Robustness: there's a bug where if you set the position before the size on macos
 	// the position will be wrong because the position uses the frame rect size implicitly

--- a/bridge/api/system/system.go
+++ b/bridge/api/system/system.go
@@ -17,10 +17,20 @@ type Display struct {
 	ScaleFactor float64
 }
 
+type PowerInfo struct {
+	IsOnBattery    bool
+	IsCharging     bool
+	BatteryPercent float64
+}
+
 type Position = misc.Position
 
 type Size = misc.Size
 
 func (m module) Displays() []Display {
 	return Displays()
+}
+
+func (m module) Power() PowerInfo {
+	return Power()
 }

--- a/bridge/api/system/system_linux.go
+++ b/bridge/api/system/system_linux.go
@@ -21,3 +21,8 @@ func Displays() (displays []Display) {
   }
   return
 }
+
+func Power() PowerInfo {
+  result := PowerInfo{}
+  return result
+}

--- a/bridge/api/system/system_linux.go
+++ b/bridge/api/system/system_linux.go
@@ -1,6 +1,12 @@
 package system
 
-import "tractor.dev/apptron/bridge/platform/linux"
+import (
+  "os/exec"
+  "strconv"
+  "strings"
+
+  "tractor.dev/apptron/bridge/platform/linux"
+)
 
 func Displays() (displays []Display) {
   for _, monitor := range linux.Monitors() {
@@ -24,5 +30,49 @@ func Displays() (displays []Display) {
 
 func Power() PowerInfo {
   result := PowerInfo{}
+
+  out, err := exec.Command("upower", "-i", "/org/freedesktop/UPower/devices/battery_BAT0").Output()
+  if err != nil {
+    return result
+  }
+
+  str := string(out)
+
+  charging := findKeyValue(str, "state:")
+  result.IsCharging = charging == "charging"
+  result.IsOnBattery = charging == "discharging"
+
+  percentStr := findKeyValue(str, "percentage:")
+  if len(percentStr) > 0 {
+    if strings.HasSuffix(percentStr, "%") {
+      percentStr = percentStr[:len(percentStr)-1]
+    }
+    percent, err := strconv.Atoi(percentStr)
+    if err == nil {
+      result.BatteryPercent = float64(percent) / 100.0
+    }
+  }
+
   return result
+}
+
+func findKeyValue(str string, key string) string {
+  start := strings.Index(str, key)
+  if start >= 0 {
+    end := start + len(key) + 1
+
+    for end < len(str) {
+      if str[end] == '\n' {
+        break
+      }
+
+      end += 1
+    }
+
+    if end < len(str) {
+      return strings.TrimSpace(str[start+len(key) : end])
+    }
+  }
+
+  return ""
 }

--- a/bridge/api/system/system_windows.go
+++ b/bridge/api/system/system_windows.go
@@ -53,3 +53,30 @@ func Displays() (displays []Display) {
 
 	return
 }
+
+func Power() PowerInfo {
+	result := PowerInfo{}
+
+	status := win32.SYSTEM_POWER_STATUS{}
+	if win32.GetSystemPowerStatus(&status) {
+		//
+		// NOTE(nick): 255 indicates "unknown status" / failed to read battery information
+		//
+		// https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-system_power_status
+		//
+
+		if status.BatteryLifePercent != 255 {
+			result.BatteryPercent = float64(status.BatteryLifePercent) / 100.0
+		}
+
+		if status.ACLineStatus != 255 {
+			result.IsOnBattery = status.ACLineStatus != 1
+		}
+
+		if status.BatteryFlag != 255 {
+			result.IsCharging = status.BatteryFlag&8 > 0
+		}
+	}
+
+	return result
+}

--- a/bridge/platform/win32/types.go
+++ b/bridge/platform/win32/types.go
@@ -287,6 +287,7 @@ type SIZE struct {
 	Cx LONG
 	Cy LONG
 }
+
 // https://docs.microsoft.com/en-us/windows/win32/api/windef/ns-windef-rect
 type RECT struct {
 	Left   LONG
@@ -457,4 +458,13 @@ type PAINTSTRUCT struct {
 	FRestore    BOOL
 	FIncUpdate  BOOL
 	RgbReserved [32]BYTE
+}
+
+type SYSTEM_POWER_STATUS struct {
+	ACLineStatus        BYTE
+	BatteryFlag         BYTE
+	BatteryLifePercent  BYTE
+	SystemStatusFlag    BYTE
+	BatteryLifeTime     DWORD
+	BatteryFullLifeTime DWORD
 }

--- a/bridge/platform/win32/win32.go
+++ b/bridge/platform/win32/win32.go
@@ -25,6 +25,8 @@ var (
 	pGlobalAlloc   = kernel32.NewProc("GlobalAlloc")
 	pGlobalFree    = kernel32.NewProc("GlobalFree")
 	pRtlMoveMemory = kernel32.NewProc("RtlMoveMemory")
+
+	pGetSystemPowerStatus = kernel32.NewProc("GetSystemPowerStatus")
 )
 
 func GetModuleHandle() HINSTANCE {
@@ -39,6 +41,11 @@ func ExitProcess(exitCode UINT) {
 func GetLastError() DWORD {
 	ret, _, _ := pGetLastError.Call()
 	return DWORD(ret)
+}
+
+func GetSystemPowerStatus(powerStatus *SYSTEM_POWER_STATUS) bool {
+	ret, _, _ := pGetSystemPowerStatus.Call(uintptr(unsafe.Pointer(powerStatus)))
+	return ret != 0
 }
 
 var (

--- a/client/system.go
+++ b/client/system.go
@@ -13,6 +13,12 @@ type Display struct {
 	ScaleFactor float64
 }
 
+type PowerInfo struct {
+	IsOnBattery    bool
+	IsCharging     bool
+	BatteryPercent float64
+}
+
 type SystemModule struct {
 	client *Client
 }
@@ -20,5 +26,11 @@ type SystemModule struct {
 // Displays
 func (m *SystemModule) Displays(ctx context.Context) (ret []Display, err error) {
 	_, err = m.client.Call(ctx, "system.Displays", fn.Args{}, &ret)
+	return
+}
+
+// Power
+func (m *SystemModule) Power(ctx context.Context) (ret PowerInfo, err error) {
+	_, err = m.client.Call(ctx, "system.Power", fn.Args{}, &ret)
 	return
 }

--- a/cmd/debug/main_cmd.go
+++ b/cmd/debug/main_cmd.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"tractor.dev/apptron"
+	"tractor.dev/apptron/bridge/api/system"
 	"tractor.dev/apptron/bridge/misc"
 	"tractor.dev/apptron/client"
 )
@@ -112,6 +113,9 @@ func main() {
 	if err := c.App.NewIndicator(ctx, iconData, trayTemplate); err != nil {
 		log.Fatal(err)
 	}
+
+	power := system.Power()
+	log.Println("[main] Power Info:", power)
 
 	c.Wait()
 }

--- a/cmd/debug/main_cmd.go
+++ b/cmd/debug/main_cmd.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"tractor.dev/apptron"
-	"tractor.dev/apptron/bridge/api/system"
 	"tractor.dev/apptron/bridge/misc"
 	"tractor.dev/apptron/client"
 )
@@ -114,7 +113,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	power := system.Power()
+	power, err := c.System.Power(ctx)
+	if err != nil {
+		log.Fatal("Error getting power info:", err)
+	}
 	log.Println("[main] Power Info:", power)
 
 	c.Wait()

--- a/cmd/debug/main_pkg.go
+++ b/cmd/debug/main_pkg.go
@@ -165,6 +165,11 @@ func run() {
 	})
 
 	platform.Dispatch(func() {
+		power := system.Power()
+		fmt.Println("[main] Power Info:", power)
+	})
+
+	platform.Dispatch(func() {
 		shell.ShowNotification(shell.Notification{
 			Title:    "Title: Hello, world",
 			Subtitle: "Subtitle: MacOS only",


### PR DESCRIPTION
Implements #52 

Wondering about what the API should be called? Was thinking `system.Power()` or `system.PowerInfo()`

For now MacOS is just using `pmset -g batt` which seems to work fine. In the future we might want to actually call the [native APIs](https://developer.apple.com/documentation/iokit/iopowersources_h) which macdriver doesn't have bindings for yet.

Not sure exactly what all the platforms will expose but windows has a bunch of [extra info in the struct](https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-system_power_status). For example it could be cool to include: charging time remaining, battery life in seconds