### PR TITLE
Style disabled field

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -133,6 +133,9 @@ button:focus {
   outline: none; 
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2);
 }
+input[type="text"]:disabled {
+  border: none;
+}
 button {
   border-radius: var(--border-radius);
   border: none;


### PR DESCRIPTION
Because it's a read-only field, we're just removing the interactivity signifier which is the border on the text field.

<img width="540" height="531" alt="image" src="https://github.com/user-attachments/assets/f1b64d17-fdff-452f-b619-16059ffccdc1" />
