### PR TITLE
Added click-outside dismissal behavior to dropdown component

### DIFF
--- a/assets/lib/dropdown.js
+++ b/assets/lib/dropdown.js
@@ -1,54 +1,75 @@
 class Dropdown extends HTMLElement {
   connectedCallback() {
-    // Get the first two child elements
     const children = this.children;
-    
+
     if (children.length < 2) {
       console.warn('popover-setup requires at least 2 child elements');
       return;
     }
-    
+
     const trigger = children[0];
     const popover = children[1];
-    
-    // Generate a unique ID for the popover if it doesn't have one
+
     if (!popover.id) {
       popover.id = `popover-${Math.random().toString(36).substr(2, 9)}`;
     }
-    
-    // Set up the trigger element
+
     trigger.setAttribute('aria-haspopup', 'menu');
     trigger.setAttribute('aria-controls', popover.id);
     trigger.setAttribute('popovertarget', popover.id);
     trigger.setAttribute('popovertargetaction', 'toggle');
-    
-    // Set up the popover element
+
     popover.setAttribute('popover', '');
-    
-    // Set up positioning
-    popover.addEventListener('toggle', (e) => {
-      if (e.newState !== 'open') return;
-      
-      const triggerRect = trigger.getBoundingClientRect();
-      const popoverRect = popover.getBoundingClientRect();
-      
-      // Get alignment from attribute (default: left)
-      const align = this.getAttribute('align') || 'left';
-      
-      let marginLeft;
-      if (align === 'right') {
-        // Align right edges
-        marginLeft = triggerRect.right - popoverRect.width;
+
+    // ===== click-outside handler =====
+    // Store handler on the instance so we can remove it later
+    this._outsideClickHandler = (event) => {
+      const path = event.composedPath();
+      // If click is inside trigger or popover, ignore
+      if (path.includes(trigger) || path.includes(popover)) return;
+      // Otherwise hide the popover
+      if (typeof popover.hidePopover === 'function') {
+        popover.hidePopover();
       } else {
-        // Align left edges (default)
-        marginLeft = triggerRect.left;
+        // Fallback if HTML popover API isn't present
+        popover.removeAttribute('open');
       }
-      
-      const marginTop = triggerRect.bottom;
-      
-      popover.style.marginLeft = `${marginLeft}px`;
-      popover.style.marginTop = `${marginTop}px`;
+    };
+
+    popover.addEventListener('toggle', (e) => {
+      if (e.newState === 'open') {
+        // Positioning logic
+        const triggerRect = trigger.getBoundingClientRect();
+        const popoverRect = popover.getBoundingClientRect();
+
+        const align = this.getAttribute('align') || 'left';
+
+        let marginLeft;
+        if (align === 'right') {
+          marginLeft = triggerRect.right - popoverRect.width;
+        } else {
+          marginLeft = triggerRect.left;
+        }
+
+        const marginTop = triggerRect.bottom;
+
+        popover.style.marginLeft = `${marginLeft}px`;
+        popover.style.marginTop = `${marginTop}px`;
+
+        // Start listening for outside clicks (capture so we run early)
+        document.addEventListener('pointerdown', this._outsideClickHandler, true);
+      } else {
+        // Popover closed: stop listening
+        document.removeEventListener('pointerdown', this._outsideClickHandler, true);
+      }
     });
+  }
+
+  disconnectedCallback() {
+    // Clean up if the element is removed while open
+    if (this._outsideClickHandler) {
+      document.removeEventListener('pointerdown', this._outsideClickHandler, true);
+    }
   }
 }
 


### PR DESCRIPTION
Adds a temporary pointerdown listener while the popover is open, dismisses when clicking outside trigger/popover, and cleans up on toggle close or component removal.

closes #214 