### PR TITLE
Set up initial playwright testing fixes #296

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ AUTH_URL=https://ad6044b5-53c2-4cb5-8542-9fdaef75f771.hanko.io
 
 # Required for Playwright tests — create a free account at mailslurp.com
 MAILSLURP_API_KEY=
+
+# Required for Playwright teardown — get this from your Hanko Cloud dashboard
+HANKO_ADMIN_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 LOCALHOST=localhost:8788
 AUTH_URL=https://ad6044b5-53c2-4cb5-8542-9fdaef75f771.hanko.io
+
+# Required for Playwright tests — create a free account at mailslurp.com
+MAILSLURP_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 LOCALHOST=localhost:8788
 AUTH_URL=https://ad6044b5-53c2-4cb5-8542-9fdaef75f771.hanko.io
 
-# Required for Playwright tests — create a free account at mailslurp.com
-MAILSLURP_API_KEY=
+# Required for Playwright tests — use shared verified pro account credentials
+MAILINATOR_API_KEY=
+MAILINATOR_DOMAIN=
 
 # Required for Playwright teardown — get this from your Hanko Cloud dashboard
 HANKO_ADMIN_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ kernel/bzImage
 go.work.sum
 go.work
 /wanix
+test-results/
+playwright-report/
+tests/.auth/
+.claude/settings.local.json
+.claude/worktrees/
+.claude/plans/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,178 @@
 {
   "name": "apptron",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "name": "apptron",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.58.2",
+        "@types/node": "^25.5.0",
+        "dotenv": "^17.3.1",
+        "mailslurp-client": "^17.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/mailslurp-client": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/mailslurp-client/-/mailslurp-client-17.0.0.tgz",
+      "integrity": "sha512-FZpmRYez34yjN1dc4vxX6Unjq43+mH0V9X+Ohbuc/xHT1YFkCW9374TkPkELV2taT5n0tJKO3REsgTqJ1IZeUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "^4.1.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@types/node": "^25.5.0",
-        "dotenv": "^17.3.1",
-        "mailslurp-client": "^17.0.0"
+        "dotenv": "^17.3.1"
       }
     },
     "node_modules/@playwright/test": {
@@ -41,16 +40,6 @@
         "undici-types": "~7.18.0"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
     "node_modules/dotenv": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -77,37 +66,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/mailslurp-client": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/mailslurp-client/-/mailslurp-client-17.0.0.tgz",
-      "integrity": "sha512-FZpmRYez34yjN1dc4vxX6Unjq43+mH0V9X+Ohbuc/xHT1YFkCW9374TkPkELV2taT5n0tJKO3REsgTqJ1IZeUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-fetch": "^4.1.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/playwright": {
@@ -142,37 +100,12 @@
         "node": ">=18"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "apptron",
+  "version": "1.0.0",
+  "description": "[![Discord](https://img.shields.io/discord/415940907729420288?label=Discord)](https://discord.gg/nQbgRjEBU4) ![GitHub Sponsors](https://img.shields.io/github/sponsors/progrium?label=Sponsors)",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2",
+    "@types/node": "^25.5.0",
+    "dotenv": "^17.3.1",
+    "mailslurp-client": "^17.0.0"
+  },
+  "scripts": {
+    "test": "playwright test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tractordev/apptron.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/tractordev/apptron/issues"
+  },
+  "homepage": "https://github.com/tractordev/apptron#readme"
+}

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.5.0",
-    "dotenv": "^17.3.1",
-    "mailslurp-client": "^17.0.0"
+    "dotenv": "^17.3.1"
   },
   "scripts": {
     "test": "playwright test"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
       name: 'setup',
       testMatch: /.*setup\.ts/,
       use: { ...devices['Desktop Chrome'] },
+      teardown: 'cleanup',
+    },
+    {
+      name: 'cleanup',
+      testMatch: /.*teardown\.ts/,
     },
     {
       name: 'chromium',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test';
+import * as dotenv from 'dotenv';
+
+// Wrangler loads .env.local automatically, but Node (and Playwright) don't.
+// We load it here so MAILSLURP_API_KEY is available in tests.
+dotenv.config({ path: '.env.local' });
+
+export default defineConfig({
+  testDir: './tests',
+  retries: 1,
+  use: {
+    baseURL: 'http://localhost:8788',
+    actionTimeout: 30000,
+  },
+  // Virtual authenticators (for passkey/WebAuthn testing) only work in Chromium
+  projects: [
+    // Runs once before all other projects — creates the test account and saves
+    // the session to tests/.auth/user.json so other tests can reuse the login.
+    {
+      name: 'setup',
+      testMatch: /.*setup\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        // Load the saved session — every test starts already logged in.
+        storageState: 'tests/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+  webServer: {
+    command: 'wrangler dev --port=8788',
+    url: 'http://localhost:8788',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,8 +24,11 @@ cp .env.example .env.local
 
 | Variable | Where to get it |
 |---|---|
+| `AUTH_URL` | Hanko Cloud dashboard → your project URL (different for local and prod) |
 | `MAILSLURP_API_KEY` | Create a free account at [mailslurp.com](https://mailslurp.com) |
-| `HANKO_ADMIN_API_KEY` | Hanko Cloud dashboard → your project → API Keys → **secret** |
+| `HANKO_ADMIN_API_KEY` | Hanko Cloud dashboard → your project → API Keys → **secret** (different for local and prod) |
+
+`AUTH_URL` and `HANKO_ADMIN_API_KEY` are environment-specific — your local Hanko project and prod Hanko project each have their own values. `.env.local` is for local development; set the prod equivalents in your deployment environment.
 
 ## Running the tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,58 @@
+# E2E Tests
+
+Playwright tests for Apptron. Tests run against a local `wrangler dev` server and use a real Hanko auth flow.
+
+## Prerequisites
+
+**1. Install dependencies**
+```bash
+npm install
+```
+
+**2. Install the Chromium browser**
+```bash
+npx playwright install chromium
+```
+
+**3. Set up environment variables**
+
+Copy `.env.example` to `.env.local` and fill in the required values:
+
+```bash
+cp .env.example .env.local
+```
+
+| Variable | Where to get it |
+|---|---|
+| `MAILSLURP_API_KEY` | Create a free account at [mailslurp.com](https://mailslurp.com) |
+| `HANKO_ADMIN_API_KEY` | Hanko Cloud dashboard → your project → API Keys → **secret** |
+
+## Running the tests
+
+```bash
+npx playwright test
+```
+
+Or with the browser visible (useful for debugging):
+
+```bash
+npx playwright test --headed
+```
+
+## How it works
+
+**Setup** (`setup.ts`) runs once before all tests. It:
+1. Creates a real MailSlurp inbox to receive the Hanko verification email
+2. Signs up a new test account via the Hanko auth flow
+3. Uses a virtual WebAuthn authenticator to register a passkey — this is in-memory only and never saves to your browser's credential store
+4. Saves the authenticated session to `tests/.auth/user.json`
+
+**Tests** (`*.test.ts`) load the saved session automatically — no sign-in needed.
+
+**Teardown** (`teardown.ts`) runs after all tests. It deletes the test account from Hanko via the admin API so nothing accumulates.
+
+## Notes
+
+- `tests/.auth/` is gitignored — it contains live session tokens and should never be committed
+- The virtual authenticator means no real passkeys are created in your browser
+- If setup fails due to a transient Hanko API error, Playwright will retry once automatically

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,7 +25,7 @@ cp .env.example .env.local
 | Variable | Where to get it |
 |---|---|
 | `AUTH_URL` | Hanko Cloud dashboard → your project URL (different for local and prod) |
-| `MAILSLURP_API_KEY` | Create a free account at [mailslurp.com](https://mailslurp.com) |
+| `MAILINATOR_API_KEY` | Use shared verified pro account credentials |
 | `HANKO_ADMIN_API_KEY` | Hanko Cloud dashboard → your project → API Keys → **secret** (different for local and prod) |
 
 `AUTH_URL` and `HANKO_ADMIN_API_KEY` are environment-specific — your local Hanko project and prod Hanko project each have their own values. `.env.local` is for local development; set the prod equivalents in your deployment environment.
@@ -45,7 +45,7 @@ npx playwright test --headed
 ## How it works
 
 **Setup** (`setup.ts`) runs once before all tests. It:
-1. Creates a real MailSlurp inbox to receive the Hanko verification email
+1. Creates a Mailinator inbox to receive the Hanko verification email
 2. Signs up a new test account via the Hanko auth flow
 3. Uses a virtual WebAuthn authenticator to register a passkey — this is in-memory only and never saves to your browser's credential store
 4. Saves the authenticated session to `tests/.auth/user.json`

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+// By the time these tests run, setup.ts has already created a test account
+// and saved the session to tests/.auth/user.json. The chromium project in
+// playwright.config.ts loads that file automatically, so every test here
+// starts fully logged in.
+
+test.describe('Authenticated user', () => {
+
+  test('lands on the dashboard after sign in', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible();
+  });
+
+});

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -12,4 +12,30 @@ test.describe('Authenticated user', () => {
     await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible();
   });
 
+//   test('can create a project and see the editor loading', async ({ page }) => {
+//     await page.goto('/dashboard');
+
+//     // wait for session and html-component custom element to be registered
+//     await page.locator('#header-bar.signedin').waitFor({ state: 'visible' });
+//     await page.waitForFunction(() => customElements.get('html-component') !== undefined);
+
+//     // click create project button and wait for modal
+//     await page.getByRole('button', { name: 'Create Project' }).click();
+//     await expect(page.getByRole('heading', { name: 'New Project' })).toBeVisible({ timeout: 30000 });
+
+//     // set a unique name per project
+//     const projectName = `project${Date.now()}`;
+//     await page.getByLabel('Project name').fill(projectName);
+
+//     // wait for duplicate name check
+//     await expect(page.locator('#project-submit')).toBeEnabled({ timeout: 15000 });
+//     await page.locator('#project-submit').click();
+
+//     // wait for editor redirect
+//     await page.waitForURL('**/edit/**', { timeout: 15000 });
+
+//     // pierce the outer iframe first, then locate the inner one
+//     await page.frameLocator('iframe').locator('#vscode-frame').waitFor({ state: 'attached' });
+//   });
+
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,9 +6,12 @@ import * as fs from 'fs';
 // The chromium project in playwright.config.ts loads this at the start of every test,
 // so tests don't need to sign in themselves.
 const authFile = 'tests/.auth/user.json';
+const userFile = 'tests/.auth/test-user.json';
 
 // A virtual authenticator simulates a hardware passkey device (like Touch ID or a USB key).
 // This lets Playwright handle WebAuthn ceremonies automatically, with no real biometrics needed.
+// Crucially, it never touches Chrome's real passkey store — credentials exist only in memory
+// for the duration of the test.
 async function setupVirtualAuthenticator(page: any, context: any) {
   const cdp = await context.newCDPSession(page);
   await cdp.send('WebAuthn.enable', { enableUI: false });
@@ -82,4 +85,7 @@ setup('create test account', async ({ page, context }) => {
   // Save cookies + localStorage so all other tests start already logged in.
   fs.mkdirSync('tests/.auth', { recursive: true });
   await page.context().storageState({ path: authFile });
+
+  // Save the email so teardown.ts can look up and delete this user via the Hanko admin API.
+  fs.writeFileSync(userFile, JSON.stringify({ email: inbox.emailAddress }));
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,85 @@
+import { test as setup } from '@playwright/test';
+import { MailSlurp } from 'mailslurp-client';
+import * as fs from 'fs';
+
+// Where the authenticated browser state (cookies + localStorage) will be saved.
+// The chromium project in playwright.config.ts loads this at the start of every test,
+// so tests don't need to sign in themselves.
+const authFile = 'tests/.auth/user.json';
+
+// A virtual authenticator simulates a hardware passkey device (like Touch ID or a USB key).
+// This lets Playwright handle WebAuthn ceremonies automatically, with no real biometrics needed.
+async function setupVirtualAuthenticator(page: any, context: any) {
+  const cdp = await context.newCDPSession(page);
+  await cdp.send('WebAuthn.enable', { enableUI: false });
+  await cdp.send('WebAuthn.addVirtualAuthenticator', {
+    options: {
+      protocol: 'ctap2',                // CTAP2 is the protocol used by modern passkeys
+      transport: 'internal',            // 'internal' = platform authenticator (e.g. Face ID / Touch ID)
+      hasResidentKey: true,             // allows the credential to be stored on the authenticator
+      hasUserVerification: true,        // supports biometric/PIN verification
+      isUserVerified: true,             // auto-passes verification (no real biometrics required)
+      automaticPresenceSimulation: true // auto-responds to "tap your key" prompts
+    },
+  });
+  return cdp;
+}
+
+setup('create test account', async ({ page, context }) => {
+  // Log browser console messages and failed network requests so we can diagnose
+  // issues with the external Hanko API without staring at a blank spinner.
+  page.on('console', (msg: any) => console.log('[browser]', msg.text()));
+  page.on('requestfailed', (req: any) =>
+    console.log('[failed request]', req.url(), req.failure()?.errorText)
+  );
+
+  await setupVirtualAuthenticator(page, context);
+  await page.goto('/signin');
+
+  // Wait for Hanko to finish initialising before interacting with it.
+  const hankoAuth = page.locator('hanko-auth');
+  await hankoAuth.getByRole('button', { name: 'Create account' }).waitFor({ state: 'visible', timeout: 30000 });
+  await hankoAuth.getByRole('button', { name: 'Create account' }).click();
+
+  // Create a real MailSlurp inbox so we can receive the Hanko verification email.
+  const mailslurp = new MailSlurp({ apiKey: process.env.MAILSLURP_API_KEY!, basePath: 'https://api.mailslurp.com' });
+  const inbox = await mailslurp.createInbox();
+
+  await hankoAuth.getByLabel('Username').fill(`testuser${Date.now()}`);
+  await hankoAuth.getByLabel('Email').fill(inbox.emailAddress!);
+  await hankoAuth.getByRole('button', { name: 'Continue' }).click();
+
+  // Hanko occasionally returns a transient "technical error" after form submission.
+  // If that happens, throw so Playwright's retry (retries: 1) re-runs setup.
+  const hankoError = hankoAuth.locator('#errorMessage');
+  if (await hankoError.isVisible({ timeout: 3000 }).catch(() => false)) {
+    throw new Error('Hanko returned a technical error — retrying');
+  }
+
+  // Wait for the passcode email and extract the 6-digit code.
+  const email = await mailslurp.waitForLatestEmail(inbox.id!, 30000);
+  const code = email.body!.match(/\d{6}/)![0];
+
+  await hankoAuth.locator('input').first().click();
+  await page.keyboard.type(code);
+
+  // Hanko may auto-submit when all 6 digits are entered, making Continue disappear.
+  // Wait for whichever comes first, then only click Continue if it's still there.
+  const createPasskeyHeading = hankoAuth.locator('h1').filter({ hasText: 'Create a passkey' });
+  const continueBtn = hankoAuth.getByRole('button', { name: 'Continue' });
+  await Promise.race([
+    createPasskeyHeading.waitFor({ state: 'visible' }),
+    continueBtn.waitFor({ state: 'visible' }),
+  ]);
+  if (await continueBtn.isVisible()) {
+    await continueBtn.click();
+  }
+
+  // The virtual authenticator intercepts navigator.credentials.create() automatically.
+  await hankoAuth.getByRole('button', { name: 'Create a passkey' }).click();
+  await page.waitForURL('**/dashboard**', { timeout: 30000 });
+
+  // Save cookies + localStorage so all other tests start already logged in.
+  fs.mkdirSync('tests/.auth', { recursive: true });
+  await page.context().storageState({ path: authFile });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,4 @@
 import { test as setup } from '@playwright/test';
-import { MailSlurp } from 'mailslurp-client';
 import * as fs from 'fs';
 
 // Where the authenticated browser state (cookies + localStorage) will be saved.
@@ -28,6 +27,31 @@ async function setupVirtualAuthenticator(page: any, context: any) {
   return cdp;
 }
 
+async function waitForMailinatorCode(inboxName: string, timeoutMs = 30000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  const apiKey = process.env.MAILINATOR_API_KEY!;
+  while (Date.now() < deadline) {
+    const domain = process.env.MAILINATOR_DOMAIN!;
+    const inboxRes = await fetch(
+      `https://mailinator.com/api/v2/domains/${domain}/inboxes/${inboxName}`,
+      { headers: { Authorization: apiKey } }
+    );
+    const inbox = await inboxRes.json() as { msgs?: { id: string }[] };
+    if (inbox.msgs && inbox.msgs.length > 0) {
+      const msgRes = await fetch(
+        `https://mailinator.com/api/v2/domains/${domain}/inboxes/${inboxName}/messages/${inbox.msgs[0].id}`,
+        { headers: { Authorization: apiKey } }
+      );
+      const msg = await msgRes.json() as { parts?: { body: string }[] };
+      const body = msg.parts?.[0]?.body ?? '';
+      const match = body.match(/\d{6}/);
+      if (match) return match[0];
+    }
+    await new Promise(r => setTimeout(r, 2000));
+  }
+  throw new Error('Timed out waiting for Mailinator email');
+}
+
 setup('create test account', async ({ page, context }) => {
   // Log browser console messages and failed network requests so we can diagnose
   // issues with the external Hanko API without staring at a blank spinner.
@@ -44,12 +68,11 @@ setup('create test account', async ({ page, context }) => {
   await hankoAuth.getByRole('button', { name: 'Create account' }).waitFor({ state: 'visible', timeout: 30000 });
   await hankoAuth.getByRole('button', { name: 'Create account' }).click();
 
-  // Create a real MailSlurp inbox so we can receive the Hanko verification email.
-  const mailslurp = new MailSlurp({ apiKey: process.env.MAILSLURP_API_KEY!, basePath: 'https://api.mailslurp.com' });
-  const inbox = await mailslurp.createInbox();
+  const inboxName = `testuser${Date.now()}`;
+  const emailAddress = `${inboxName}@${process.env.MAILINATOR_DOMAIN}`;
 
-  await hankoAuth.getByLabel('Username').fill(`testuser${Date.now()}`);
-  await hankoAuth.getByLabel('Email').fill(inbox.emailAddress!);
+  await hankoAuth.getByLabel('Username').fill(inboxName);
+  await hankoAuth.getByLabel('Email').fill(emailAddress);
   await hankoAuth.getByRole('button', { name: 'Continue' }).click();
 
   // Hanko occasionally returns a transient "technical error" after form submission.
@@ -59,9 +82,8 @@ setup('create test account', async ({ page, context }) => {
     throw new Error('Hanko returned a technical error — retrying');
   }
 
-  // Wait for the passcode email and extract the 6-digit code.
-  const email = await mailslurp.waitForLatestEmail(inbox.id!, 30000);
-  const code = email.body!.match(/\d{6}/)![0];
+  // Poll Mailinator for the passcode email and extract the 6-digit code.
+  const code = await waitForMailinatorCode(inboxName);
 
   await hankoAuth.locator('input').first().click();
   await page.keyboard.type(code);
@@ -87,5 +109,5 @@ setup('create test account', async ({ page, context }) => {
   await page.context().storageState({ path: authFile });
 
   // Save the email so teardown.ts can look up and delete this user via the Hanko admin API.
-  fs.writeFileSync(userFile, JSON.stringify({ email: inbox.emailAddress }));
+  fs.writeFileSync(userFile, JSON.stringify({ email: emailAddress }));
 });

--- a/tests/teardown.ts
+++ b/tests/teardown.ts
@@ -1,0 +1,49 @@
+import { test as teardown } from '@playwright/test';
+import * as fs from 'fs';
+
+const userFile = 'tests/.auth/test-user.json';
+
+teardown('delete test account', async () => {
+  if (!fs.existsSync(userFile)) {
+    console.log('[teardown] No test user file found, skipping.');
+    return;
+  }
+
+  const { email } = JSON.parse(fs.readFileSync(userFile, 'utf-8'));
+  const adminApiKey = process.env.HANKO_ADMIN_API_KEY!;
+  const adminUrl = `${process.env.AUTH_URL}/admin/users`;;
+
+  const headers = {
+    Authorization: `Bearer ${adminApiKey}`,
+    'Content-Type': 'application/json',
+  };
+
+  // Look up the user by email to get their ID.
+  const listRes = await fetch(`${adminUrl}?email=${encodeURIComponent(email)}`, { headers });
+  if (!listRes.ok) {
+    throw new Error(`Failed to list users: ${listRes.status} ${await listRes.text()}`);
+  }
+
+  const users = await listRes.json() as Array<{ id: string }>;
+  if (users.length === 0) {
+    console.log(`[teardown] No Hanko user found for ${email}, skipping delete.`);
+    return;
+  }
+
+  const userId = users[0].id;
+
+  // Delete the user.
+  const deleteRes = await fetch(`${adminUrl}/${userId}`, { method: 'DELETE', headers });
+  if (!deleteRes.ok && deleteRes.status !== 404) {
+    throw new Error(`Failed to delete user ${userId}: ${deleteRes.status} ${await deleteRes.text()}`);
+  }
+
+  // Verify the user is gone — expect a 404.
+  const verifyRes = await fetch(`${adminUrl}/${userId}`, { headers });
+  if (verifyRes.status !== 404) {
+    throw new Error(`Expected user ${userId} to be deleted but got status ${verifyRes.status}`);
+  }
+
+  console.log(`[teardown] Deleted and verified removal of Hanko user ${userId} (${email})`);
+  fs.unlinkSync(userFile);
+});


### PR DESCRIPTION
- Add Playwright E2E test infrastructure with Chromium, virtual WebAuthn authenticator, and MailSlurp for email OTP — enabling automated testing of the full passkey-based signup flow
- Introduce a setup project that runs once before all tests, creates a real test account via Hanko auth, and saves the browser session to tests/.auth/user.json so subsequent tests start already logged in
- Add first authenticated test: verifies a signed-in user lands on the dashboard and sees the Projects heading
- Configure test retries, 30s action/navigation timeouts, and automatic wrangler dev server startup via webServer in playwright.config.ts
- Update .gitignore to exclude test auth state (tests/.auth/), local Claude settings
- Add MAILSLURP_API_KEY to .env.example to document the required secret for collaborators