### PR TITLE
Convert 2-space indentation to 4-space for consistency

### DIFF
--- a/assets/_frame.html
+++ b/assets/_frame.html
@@ -1,110 +1,110 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Apptron</title>
-  <meta name="viewport"
-    content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <style>
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
-
-    html,
-    body {
-      height: 100%;
-      width: 100%;
-      overflow: hidden;
-    }
-
-    iframe {
-      width: 100%;
-      height: 100%;
-      border: none;
-      display: block;
-    }
-  </style>
-  <script type="module">
-    // copied from apptron.js to avoid import
-    function isLocalhost() {
-        const hostname = window.location.hostname;
-        return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
-    }
-    function appHost() {
-      const hostname = window.location.origin.replace("https://", "").replace("http://", "");
-      if (isLocalhost()) {
-        return hostname;
-      }
-      const parts = hostname.split(".");
-      if (parts.length >= 2) {
-        return parts.slice(-2).join(".");
-      }
-      return hostname;
-    }
-
-    // accept messages to redirect at the top level
-    // this handles redirects, a kv store for sharing data between frames, 
-    // and a wanix port factory for registering and handing off wanix ports to other frames
-    let factory = undefined;
-    let storage = new Map();
-    window.onmessage = (event) => {
-      // console.log("top frame message:", event.data, event.origin);
-      if (event.data.type === "store") {
-        storage.set(event.data.token, {
-          value: event.data.value,
-          transfers: event.data.transfers || []
-        });
-        return;
-      }
-      if (event.data.type === "load") {
-        const obj = storage.get(event.data.token);
-        if (!obj) {
-          console.warn("no value found for token", event.data.token);
-          return;
+    <meta charset="UTF-8">
+    <title>Apptron</title>
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
         }
-        // console.log('load', event.data.token, value);
-        event.data.reply.postMessage(obj, obj.transfers);
-        storage.delete(event.data.token);
-        return;
-      }
-      // factory is a port that can be used to create a new port
-      if (event.data.factory) {
-        factory = event.data.factory;
-        return;
-      }
-      // we need to send the port to the factory to create a new port.
-      if (event.data.service === "wanix") {
-        if (!factory) {
-          console.warn("no factory found");
-          return;
+
+        html,
+        body {
+            height: 100%;
+            width: 100%;
+            overflow: hidden;
         }
-        factory.postMessage({ port: event.data.port }, [event.data.port]);
-        return;
-      }
 
-      if (!event.origin.endsWith(appHost())) {
-        console.log("origin not allowed", event.origin, appHost());
-        return;
-      }
-      if (event.data.redirect) {
-        window.location.href = event.data.redirect;
-        return;
-      }
-      if (event.data.self && event.data.reply) {
-        event.data.reply.postMessage(window.location.href);
-        return;
-      }
-    }
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
+            display: block;
+        }
+    </style>
+    <script type="module">
+        // copied from apptron.js to avoid import
+        function isLocalhost() {
+            const hostname = window.location.hostname;
+            return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+        }
+        function appHost() {
+            const hostname = window.location.origin.replace("https://", "").replace("http://", "");
+            if (isLocalhost()) {
+                return hostname;
+            }
+            const parts = hostname.split(".");
+            if (parts.length >= 2) {
+                return parts.slice(-2).join(".");
+            }
+            return hostname;
+        }
 
-    // console.log("top frame origin", location.origin);
-  </script>
+        // accept messages to redirect at the top level
+        // this handles redirects, a kv store for sharing data between frames, 
+        // and a wanix port factory for registering and handing off wanix ports to other frames
+        let factory = undefined;
+        let storage = new Map();
+        window.onmessage = (event) => {
+            // console.log("top frame message:", event.data, event.origin);
+            if (event.data.type === "store") {
+                storage.set(event.data.token, {
+                    value: event.data.value,
+                    transfers: event.data.transfers || []
+                });
+                return;
+            }
+            if (event.data.type === "load") {
+                const obj = storage.get(event.data.token);
+                if (!obj) {
+                    console.warn("no value found for token", event.data.token);
+                    return;
+                }
+                // console.log('load', event.data.token, value);
+                event.data.reply.postMessage(obj, obj.transfers);
+                storage.delete(event.data.token);
+                return;
+            }
+            // factory is a port that can be used to create a new port
+            if (event.data.factory) {
+                factory = event.data.factory;
+                return;
+            }
+            // we need to send the port to the factory to create a new port.
+            if (event.data.service === "wanix") {
+                if (!factory) {
+                    console.warn("no factory found");
+                    return;
+                }
+                factory.postMessage({ port: event.data.port }, [event.data.port]);
+                return;
+            }
+
+            if (!event.origin.endsWith(appHost())) {
+                console.log("origin not allowed", event.origin, appHost());
+                return;
+            }
+            if (event.data.redirect) {
+                window.location.href = event.data.redirect;
+                return;
+            }
+            if (event.data.self && event.data.reply) {
+                event.data.reply.postMessage(window.location.href);
+                return;
+            }
+        }
+
+        // console.log("top frame origin", location.origin);
+    </script>
 </head>
 
 <body>
-  <!-- injected environment iframe -->
+    <!-- injected environment iframe -->
 </body>
 
 </html>

--- a/assets/_frame.html
+++ b/assets/_frame.html
@@ -1,110 +1,110 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <title>Apptron</title>
-    <meta name="viewport"
-        content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+  <meta charset="UTF-8">
+  <title>Apptron</title>
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
 
-        html,
-        body {
-            height: 100%;
-            width: 100%;
-            overflow: hidden;
-        }
+    html,
+    body {
+      height: 100%;
+      width: 100%;
+      overflow: hidden;
+    }
 
-        iframe {
-            width: 100%;
-            height: 100%;
-            border: none;
-            display: block;
-        }
-    </style>
-    <script type="module">
-        // copied from apptron.js to avoid import
-        function isLocalhost() {
-            const hostname = window.location.hostname;
-            return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
-        }
-        function appHost() {
-            const hostname = window.location.origin.replace("https://", "").replace("http://", "");
-            if (isLocalhost()) {
-                return hostname;
-            }
-            const parts = hostname.split(".");
-            if (parts.length >= 2) {
-                return parts.slice(-2).join(".");
-            }
-            return hostname;
-        }
+    iframe {
+      width: 100%;
+      height: 100%;
+      border: none;
+      display: block;
+    }
+  </style>
+  <script type="module">
+    // copied from apptron.js to avoid import
+    function isLocalhost() {
+        const hostname = window.location.hostname;
+        return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+    }
+    function appHost() {
+      const hostname = window.location.origin.replace("https://", "").replace("http://", "");
+      if (isLocalhost()) {
+        return hostname;
+      }
+      const parts = hostname.split(".");
+      if (parts.length >= 2) {
+        return parts.slice(-2).join(".");
+      }
+      return hostname;
+    }
 
-        // accept messages to redirect at the top level
-        // this handles redirects, a kv store for sharing data between frames, 
-        // and a wanix port factory for registering and handing off wanix ports to other frames
-        let factory = undefined;
-        let storage = new Map();
-        window.onmessage = (event) => {
-            // console.log("top frame message:", event.data, event.origin);
-            if (event.data.type === "store") {
-                storage.set(event.data.token, {
-                    value: event.data.value,
-                    transfers: event.data.transfers || []
-                });
-                return;
-            }
-            if (event.data.type === "load") {
-                const obj = storage.get(event.data.token);
-                if (!obj) {
-                    console.warn("no value found for token", event.data.token);
-                    return;
-                }
-                // console.log('load', event.data.token, value);
-                event.data.reply.postMessage(obj, obj.transfers);
-                storage.delete(event.data.token);
-                return;
-            }
-            // factory is a port that can be used to create a new port
-            if (event.data.factory) {
-                factory = event.data.factory;
-                return;
-            }
-            // we need to send the port to the factory to create a new port.
-            if (event.data.service === "wanix") {
-                if (!factory) {
-                    console.warn("no factory found");
-                    return;
-                }
-                factory.postMessage({ port: event.data.port }, [event.data.port]);
-                return;
-            }
-
-            if (!event.origin.endsWith(appHost())) {
-                console.log("origin not allowed", event.origin, appHost());
-                return;
-            }
-            if (event.data.redirect) {
-                window.location.href = event.data.redirect;
-                return;
-            }
-            if (event.data.self && event.data.reply) {
-                event.data.reply.postMessage(window.location.href);
-                return;
-            }
+    // accept messages to redirect at the top level
+    // this handles redirects, a kv store for sharing data between frames, 
+    // and a wanix port factory for registering and handing off wanix ports to other frames
+    let factory = undefined;
+    let storage = new Map();
+    window.onmessage = (event) => {
+      // console.log("top frame message:", event.data, event.origin);
+      if (event.data.type === "store") {
+        storage.set(event.data.token, {
+          value: event.data.value,
+          transfers: event.data.transfers || []
+        });
+        return;
+      }
+      if (event.data.type === "load") {
+        const obj = storage.get(event.data.token);
+        if (!obj) {
+          console.warn("no value found for token", event.data.token);
+          return;
         }
+        // console.log('load', event.data.token, value);
+        event.data.reply.postMessage(obj, obj.transfers);
+        storage.delete(event.data.token);
+        return;
+      }
+      // factory is a port that can be used to create a new port
+      if (event.data.factory) {
+        factory = event.data.factory;
+        return;
+      }
+      // we need to send the port to the factory to create a new port.
+      if (event.data.service === "wanix") {
+        if (!factory) {
+          console.warn("no factory found");
+          return;
+        }
+        factory.postMessage({ port: event.data.port }, [event.data.port]);
+        return;
+      }
 
-        // console.log("top frame origin", location.origin);
-    </script>
+      if (!event.origin.endsWith(appHost())) {
+        console.log("origin not allowed", event.origin, appHost());
+        return;
+      }
+      if (event.data.redirect) {
+        window.location.href = event.data.redirect;
+        return;
+      }
+      if (event.data.self && event.data.reply) {
+        event.data.reply.postMessage(window.location.href);
+        return;
+      }
+    }
+
+    // console.log("top frame origin", location.origin);
+  </script>
 </head>
 
 <body>
-    <!-- injected environment iframe -->
+  <!-- injected environment iframe -->
 </body>
 
 </html>

--- a/assets/lib/dropdown.js
+++ b/assets/lib/dropdown.js
@@ -1,76 +1,76 @@
 class Dropdown extends HTMLElement {
-    connectedCallback() {
-        const children = this.children;
+  connectedCallback() {
+    const children = this.children;
 
-        if (children.length < 2) {
-            console.warn('popover-setup requires at least 2 child elements');
-            return;
-        }
-
-        const trigger = children[0];
-        const popover = children[1];
-
-        if (!popover.id) {
-            popover.id = `popover-${Math.random().toString(36).substr(2, 9)}`;
-        }
-
-        trigger.setAttribute('aria-haspopup', 'menu');
-        trigger.setAttribute('aria-controls', popover.id);
-        trigger.setAttribute('popovertarget', popover.id);
-        trigger.setAttribute('popovertargetaction', 'toggle');
-
-        popover.setAttribute('popover', '');
-
-        // ===== click-outside handler =====
-        // Store handler on the instance so we can remove it later
-        this._outsideClickHandler = (event) => {
-            const path = event.composedPath();
-            // If click is inside trigger or popover, ignore
-            if (path.includes(trigger) || path.includes(popover)) return;
-            // Otherwise hide the popover
-            if (typeof popover.hidePopover === 'function') {
-                popover.hidePopover();
-            } else {
-                // Fallback if HTML popover API isn't present
-                popover.removeAttribute('open');
-            }
-        };
-
-        popover.addEventListener('toggle', (e) => {
-            if (e.newState === 'open') {
-                // Positioning logic
-                const triggerRect = trigger.getBoundingClientRect();
-                const popoverRect = popover.getBoundingClientRect();
-
-                const align = this.getAttribute('align') || 'left';
-
-                let marginLeft;
-                if (align === 'right') {
-                    marginLeft = triggerRect.right - popoverRect.width;
-                } else {
-                    marginLeft = triggerRect.left;
-                }
-
-                const marginTop = triggerRect.bottom;
-
-                popover.style.marginLeft = `${marginLeft}px`;
-                popover.style.marginTop = `${marginTop}px`;
-
-                // Start listening for outside clicks (capture so we run early)
-                document.addEventListener('pointerdown', this._outsideClickHandler, true);
-            } else {
-                // Popover closed: stop listening
-                document.removeEventListener('pointerdown', this._outsideClickHandler, true);
-            }
-        });
+    if (children.length < 2) {
+      console.warn('popover-setup requires at least 2 child elements');
+      return;
     }
 
-    disconnectedCallback() {
-        // Clean up if the element is removed while open
-        if (this._outsideClickHandler) {
-            document.removeEventListener('pointerdown', this._outsideClickHandler, true);
-        }
+    const trigger = children[0];
+    const popover = children[1];
+
+    if (!popover.id) {
+      popover.id = `popover-${Math.random().toString(36).substr(2, 9)}`;
     }
+
+    trigger.setAttribute('aria-haspopup', 'menu');
+    trigger.setAttribute('aria-controls', popover.id);
+    trigger.setAttribute('popovertarget', popover.id);
+    trigger.setAttribute('popovertargetaction', 'toggle');
+
+    popover.setAttribute('popover', '');
+
+    // ===== click-outside handler =====
+    // Store handler on the instance so we can remove it later
+    this._outsideClickHandler = (event) => {
+      const path = event.composedPath();
+      // If click is inside trigger or popover, ignore
+      if (path.includes(trigger) || path.includes(popover)) return;
+      // Otherwise hide the popover
+      if (typeof popover.hidePopover === 'function') {
+        popover.hidePopover();
+      } else {
+        // Fallback if HTML popover API isn't present
+        popover.removeAttribute('open');
+      }
+    };
+
+    popover.addEventListener('toggle', (e) => {
+      if (e.newState === 'open') {
+        // Positioning logic
+        const triggerRect = trigger.getBoundingClientRect();
+        const popoverRect = popover.getBoundingClientRect();
+
+        const align = this.getAttribute('align') || 'left';
+
+        let marginLeft;
+        if (align === 'right') {
+          marginLeft = triggerRect.right - popoverRect.width;
+        } else {
+          marginLeft = triggerRect.left;
+        }
+
+        const marginTop = triggerRect.bottom;
+
+        popover.style.marginLeft = `${marginLeft}px`;
+        popover.style.marginTop = `${marginTop}px`;
+
+        // Start listening for outside clicks (capture so we run early)
+        document.addEventListener('pointerdown', this._outsideClickHandler, true);
+      } else {
+        // Popover closed: stop listening
+        document.removeEventListener('pointerdown', this._outsideClickHandler, true);
+      }
+    });
+  }
+
+  disconnectedCallback() {
+    // Clean up if the element is removed while open
+    if (this._outsideClickHandler) {
+      document.removeEventListener('pointerdown', this._outsideClickHandler, true);
+    }
+  }
 }
 
 customElements.define('apptron-dropdown', Dropdown);

--- a/assets/lib/dropdown.js
+++ b/assets/lib/dropdown.js
@@ -1,76 +1,76 @@
 class Dropdown extends HTMLElement {
-  connectedCallback() {
-    const children = this.children;
+    connectedCallback() {
+        const children = this.children;
 
-    if (children.length < 2) {
-      console.warn('popover-setup requires at least 2 child elements');
-      return;
-    }
-
-    const trigger = children[0];
-    const popover = children[1];
-
-    if (!popover.id) {
-      popover.id = `popover-${Math.random().toString(36).substr(2, 9)}`;
-    }
-
-    trigger.setAttribute('aria-haspopup', 'menu');
-    trigger.setAttribute('aria-controls', popover.id);
-    trigger.setAttribute('popovertarget', popover.id);
-    trigger.setAttribute('popovertargetaction', 'toggle');
-
-    popover.setAttribute('popover', '');
-
-    // ===== click-outside handler =====
-    // Store handler on the instance so we can remove it later
-    this._outsideClickHandler = (event) => {
-      const path = event.composedPath();
-      // If click is inside trigger or popover, ignore
-      if (path.includes(trigger) || path.includes(popover)) return;
-      // Otherwise hide the popover
-      if (typeof popover.hidePopover === 'function') {
-        popover.hidePopover();
-      } else {
-        // Fallback if HTML popover API isn't present
-        popover.removeAttribute('open');
-      }
-    };
-
-    popover.addEventListener('toggle', (e) => {
-      if (e.newState === 'open') {
-        // Positioning logic
-        const triggerRect = trigger.getBoundingClientRect();
-        const popoverRect = popover.getBoundingClientRect();
-
-        const align = this.getAttribute('align') || 'left';
-
-        let marginLeft;
-        if (align === 'right') {
-          marginLeft = triggerRect.right - popoverRect.width;
-        } else {
-          marginLeft = triggerRect.left;
+        if (children.length < 2) {
+            console.warn('popover-setup requires at least 2 child elements');
+            return;
         }
 
-        const marginTop = triggerRect.bottom;
+        const trigger = children[0];
+        const popover = children[1];
 
-        popover.style.marginLeft = `${marginLeft}px`;
-        popover.style.marginTop = `${marginTop}px`;
+        if (!popover.id) {
+            popover.id = `popover-${Math.random().toString(36).substr(2, 9)}`;
+        }
 
-        // Start listening for outside clicks (capture so we run early)
-        document.addEventListener('pointerdown', this._outsideClickHandler, true);
-      } else {
-        // Popover closed: stop listening
-        document.removeEventListener('pointerdown', this._outsideClickHandler, true);
-      }
-    });
-  }
+        trigger.setAttribute('aria-haspopup', 'menu');
+        trigger.setAttribute('aria-controls', popover.id);
+        trigger.setAttribute('popovertarget', popover.id);
+        trigger.setAttribute('popovertargetaction', 'toggle');
 
-  disconnectedCallback() {
-    // Clean up if the element is removed while open
-    if (this._outsideClickHandler) {
-      document.removeEventListener('pointerdown', this._outsideClickHandler, true);
+        popover.setAttribute('popover', '');
+
+        // ===== click-outside handler =====
+        // Store handler on the instance so we can remove it later
+        this._outsideClickHandler = (event) => {
+            const path = event.composedPath();
+            // If click is inside trigger or popover, ignore
+            if (path.includes(trigger) || path.includes(popover)) return;
+            // Otherwise hide the popover
+            if (typeof popover.hidePopover === 'function') {
+                popover.hidePopover();
+            } else {
+                // Fallback if HTML popover API isn't present
+                popover.removeAttribute('open');
+            }
+        };
+
+        popover.addEventListener('toggle', (e) => {
+            if (e.newState === 'open') {
+                // Positioning logic
+                const triggerRect = trigger.getBoundingClientRect();
+                const popoverRect = popover.getBoundingClientRect();
+
+                const align = this.getAttribute('align') || 'left';
+
+                let marginLeft;
+                if (align === 'right') {
+                    marginLeft = triggerRect.right - popoverRect.width;
+                } else {
+                    marginLeft = triggerRect.left;
+                }
+
+                const marginTop = triggerRect.bottom;
+
+                popover.style.marginLeft = `${marginLeft}px`;
+                popover.style.marginTop = `${marginTop}px`;
+
+                // Start listening for outside clicks (capture so we run early)
+                document.addEventListener('pointerdown', this._outsideClickHandler, true);
+            } else {
+                // Popover closed: stop listening
+                document.removeEventListener('pointerdown', this._outsideClickHandler, true);
+            }
+        });
     }
-  }
+
+    disconnectedCallback() {
+        // Clean up if the element is removed while open
+        if (this._outsideClickHandler) {
+            document.removeEventListener('pointerdown', this._outsideClickHandler, true);
+        }
+    }
 }
 
 customElements.define('apptron-dropdown', Dropdown);

--- a/assets/lib/html-component.js
+++ b/assets/lib/html-component.js
@@ -1,117 +1,117 @@
 export class HTMLComponent extends HTMLElement {
-    constructor() {
-        super();
-        this.attachShadow({ mode: 'open' });
-        this._scriptContexts = new Map();
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this._scriptContexts = new Map();
+  }
+  
+  static get observedAttributes() {
+    return ['src'];
+  }
+  
+  connectedCallback() {
+    const src = this.getAttribute('src');
+    if (src) {
+      this.load(src);
     }
-    
-    static get observedAttributes() {
-        return ['src'];
+  }
+  
+  async load(url) {
+    try {
+      const response = await fetch(url);
+      const html = await response.text();
+      
+      // Parse and process the template
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
+      const com = doc.querySelector('html');
+      
+      if (!com) {
+        throw new Error('No component found');
+      }
+      
+      // Create a document fragment from template content
+      const fragment = document.createDocumentFragment();
+      const tempContainer = document.createElement('div');
+      tempContainer.innerHTML = com.innerHTML;
+      
+      // Process each node
+      this.processNodes(tempContainer, fragment);
+      
+      // Clear and append to shadow root
+      this.shadowRoot.innerHTML = '';
+      this.shadowRoot.appendChild(fragment);
+      
+      // Initialize any scripts after DOM is ready
+      await this.initializeScripts();
+      
+      // Fire loaded event
+      this.dispatchEvent(new CustomEvent('loaded', { 
+        detail: { url },
+        bubbles: true 
+      }));
+      
+    } catch (error) {
+      this.handleError(error);
     }
-    
-    connectedCallback() {
-        const src = this.getAttribute('src');
-        if (src) {
-            this.load(src);
+  }
+  
+  processNodes(source, target) {
+    Array.from(source.childNodes).forEach(node => {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        if (node.tagName === 'SCRIPT') {
+          // Store script for later execution
+          this._scriptContexts.set(node, node.textContent || node.src);
+        } else {
+          // Clone and append other elements
+          const cloned = node.cloneNode(true);
+          target.appendChild(cloned);
         }
+      } else {
+        // Clone text nodes and comments
+        target.appendChild(node.cloneNode(true));
+      }
+    });
+  }
+  
+  async initializeScripts() {
+    for (const [scriptNode, content] of this._scriptContexts) {
+      if (scriptNode.src) {
+        // Load external script
+        const script = document.createElement('script');
+        script.src = scriptNode.src;
+        script.type = scriptNode.type || 'text/javascript';
+        this.shadowRoot.appendChild(script);
+      } else {
+        // Execute inline script with shadow DOM context (supports import and await)
+        await this.executeInlineScript(content);
+      }
     }
     
-    async load(url) {
-        try {
-            const response = await fetch(url);
-            const html = await response.text();
-            
-            // Parse and process the template
-            const parser = new DOMParser();
-            const doc = parser.parseFromString(html, 'text/html');
-            const com = doc.querySelector('html');
-            
-            if (!com) {
-                throw new Error('No component found');
-            }
-            
-            // Create a document fragment from template content
-            const fragment = document.createDocumentFragment();
-            const tempContainer = document.createElement('div');
-            tempContainer.innerHTML = com.innerHTML;
-            
-            // Process each node
-            this.processNodes(tempContainer, fragment);
-            
-            // Clear and append to shadow root
-            this.shadowRoot.innerHTML = '';
-            this.shadowRoot.appendChild(fragment);
-            
-            // Initialize any scripts after DOM is ready
-            await this.initializeScripts();
-            
-            // Fire loaded event
-            this.dispatchEvent(new CustomEvent('loaded', { 
-                detail: { url },
-                bubbles: true 
-            }));
-            
-        } catch (error) {
-            this.handleError(error);
-        }
-    }
-    
-    processNodes(source, target) {
-        Array.from(source.childNodes).forEach(node => {
-            if (node.nodeType === Node.ELEMENT_NODE) {
-                if (node.tagName === 'SCRIPT') {
-                    // Store script for later execution
-                    this._scriptContexts.set(node, node.textContent || node.src);
-                } else {
-                    // Clone and append other elements
-                    const cloned = node.cloneNode(true);
-                    target.appendChild(cloned);
-                }
-            } else {
-                // Clone text nodes and comments
-                target.appendChild(node.cloneNode(true));
-            }
-        });
-    }
-    
-    async initializeScripts() {
-        for (const [scriptNode, content] of this._scriptContexts) {
-            if (scriptNode.src) {
-                // Load external script
-                const script = document.createElement('script');
-                script.src = scriptNode.src;
-                script.type = scriptNode.type || 'text/javascript';
-                this.shadowRoot.appendChild(script);
-            } else {
-                // Execute inline script with shadow DOM context (supports import and await)
-                await this.executeInlineScript(content);
-            }
-        }
-        
-        // Clear stored scripts
-        this._scriptContexts.clear();
-    }
-    
-    async executeInlineScript(code) {
-        try {
-            // Create a unique context ID for this script execution
-            const contextId = `__htmlComponent_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-            
-            // Store context in a temporary global variable
-            window[contextId] = {
-                shadowRoot: this.shadowRoot,
-                component: this,
-                $: (selector) => this.shadowRoot.querySelector(selector),
-                $$: (selector) => this.shadowRoot.querySelectorAll(selector)
-            };
-            
-            // Resolve relative imports to absolute URLs
-            // This is necessary because blob URLs don't have a proper base for resolution
-            const resolvedCode = this.resolveImports(code);
-            
-            // Create a module script that retrieves the context
-            // This allows use of import and await
-            const moduleCode = `
+    // Clear stored scripts
+    this._scriptContexts.clear();
+  }
+  
+  async executeInlineScript(code) {
+    try {
+      // Create a unique context ID for this script execution
+      const contextId = `__htmlComponent_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+      
+      // Store context in a temporary global variable
+      window[contextId] = {
+        shadowRoot: this.shadowRoot,
+        component: this,
+        $: (selector) => this.shadowRoot.querySelector(selector),
+        $$: (selector) => this.shadowRoot.querySelectorAll(selector)
+      };
+      
+      // Resolve relative imports to absolute URLs
+      // This is necessary because blob URLs don't have a proper base for resolution
+      const resolvedCode = this.resolveImports(code);
+      
+      // Create a module script that retrieves the context
+      // This allows use of import and await
+      const moduleCode = `
         const { shadowRoot, component, $, $$ } = window['${contextId}'];
         
         // Clean up the global context immediately after retrieval
@@ -119,62 +119,62 @@ export class HTMLComponent extends HTMLElement {
         
         // Execute the original script (with import and await support)
         ${resolvedCode}
-            `;
-            
-            // Create a blob URL for the module
-            const blob = new Blob([moduleCode], { type: 'text/javascript' });
-            const url = URL.createObjectURL(blob);
-            
-            try {
-                // Import and execute as a module
-                await import(url);
-            } finally {
-                // Clean up the blob URL
-                URL.revokeObjectURL(url);
-                // Ensure context is cleaned up even if script fails
-                delete window[contextId];
-            }
-            
-        } catch (error) {
-            console.error('Script execution error:', error);
-        }
+      `;
+      
+      // Create a blob URL for the module
+      const blob = new Blob([moduleCode], { type: 'text/javascript' });
+      const url = URL.createObjectURL(blob);
+      
+      try {
+        // Import and execute as a module
+        await import(url);
+      } finally {
+        // Clean up the blob URL
+        URL.revokeObjectURL(url);
+        // Ensure context is cleaned up even if script fails
+        delete window[contextId];
+      }
+      
+    } catch (error) {
+      console.error('Script execution error:', error);
     }
-    
-    resolveImports(code) {
-        // Replace import statements with absolute URLs
-        // Matches: import ... from "path" or import ... from 'path'
-        return code.replace(
-            /import\s+(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)(?:\s*,\s*(?:\{[^}]*\}|\*\s+as\s+\w+|\w+))*\s+from\s+)?['"]([^'"]+)['"]/g,
-            (match, path) => {
-                // Convert relative paths to absolute URLs
-                const absoluteUrl = new URL(path, window.location.origin + window.location.pathname).href;
-                return match.replace(path, absoluteUrl);
-            }
-        );
-    }
-    
-    handleError(error) {
-        console.error('Component loading error:', error);
-        this.shadowRoot.innerHTML = `
+  }
+  
+  resolveImports(code) {
+    // Replace import statements with absolute URLs
+    // Matches: import ... from "path" or import ... from 'path'
+    return code.replace(
+      /import\s+(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)(?:\s*,\s*(?:\{[^}]*\}|\*\s+as\s+\w+|\w+))*\s+from\s+)?['"]([^'"]+)['"]/g,
+      (match, path) => {
+        // Convert relative paths to absolute URLs
+        const absoluteUrl = new URL(path, window.location.origin + window.location.pathname).href;
+        return match.replace(path, absoluteUrl);
+      }
+    );
+  }
+  
+  handleError(error) {
+    console.error('Component loading error:', error);
+    this.shadowRoot.innerHTML = `
       <div style="padding: 10px; background: #fee; color: #c00; border: 1px solid #c00; border-radius: 4px;">
         <strong>Error:</strong> ${error.message}
       </div>
-        `;
-        
-        this.dispatchEvent(new CustomEvent('error', {
-            detail: { error },
-            bubbles: true
-        }));
-    }
+    `;
     
-    // Utility methods for external access
-    getElement(selector) {
-        return this.shadowRoot.querySelector(selector);
-    }
-    
-    getElements(selector) {
-        return this.shadowRoot.querySelectorAll(selector);
-    }
+    this.dispatchEvent(new CustomEvent('error', {
+      detail: { error },
+      bubbles: true
+    }));
+  }
+  
+  // Utility methods for external access
+  getElement(selector) {
+    return this.shadowRoot.querySelector(selector);
+  }
+  
+  getElements(selector) {
+    return this.shadowRoot.querySelectorAll(selector);
+  }
 }
-    
+  
 customElements.define('html-component', HTMLComponent);

--- a/assets/lib/html-component.js
+++ b/assets/lib/html-component.js
@@ -1,117 +1,117 @@
 export class HTMLComponent extends HTMLElement {
-  constructor() {
-    super();
-    this.attachShadow({ mode: 'open' });
-    this._scriptContexts = new Map();
-  }
-  
-  static get observedAttributes() {
-    return ['src'];
-  }
-  
-  connectedCallback() {
-    const src = this.getAttribute('src');
-    if (src) {
-      this.load(src);
-    }
-  }
-  
-  async load(url) {
-    try {
-      const response = await fetch(url);
-      const html = await response.text();
-      
-      // Parse and process the template
-      const parser = new DOMParser();
-      const doc = parser.parseFromString(html, 'text/html');
-      const com = doc.querySelector('html');
-      
-      if (!com) {
-        throw new Error('No component found');
-      }
-      
-      // Create a document fragment from template content
-      const fragment = document.createDocumentFragment();
-      const tempContainer = document.createElement('div');
-      tempContainer.innerHTML = com.innerHTML;
-      
-      // Process each node
-      this.processNodes(tempContainer, fragment);
-      
-      // Clear and append to shadow root
-      this.shadowRoot.innerHTML = '';
-      this.shadowRoot.appendChild(fragment);
-      
-      // Initialize any scripts after DOM is ready
-      await this.initializeScripts();
-      
-      // Fire loaded event
-      this.dispatchEvent(new CustomEvent('loaded', { 
-        detail: { url },
-        bubbles: true 
-      }));
-      
-    } catch (error) {
-      this.handleError(error);
-    }
-  }
-  
-  processNodes(source, target) {
-    Array.from(source.childNodes).forEach(node => {
-      if (node.nodeType === Node.ELEMENT_NODE) {
-        if (node.tagName === 'SCRIPT') {
-          // Store script for later execution
-          this._scriptContexts.set(node, node.textContent || node.src);
-        } else {
-          // Clone and append other elements
-          const cloned = node.cloneNode(true);
-          target.appendChild(cloned);
-        }
-      } else {
-        // Clone text nodes and comments
-        target.appendChild(node.cloneNode(true));
-      }
-    });
-  }
-  
-  async initializeScripts() {
-    for (const [scriptNode, content] of this._scriptContexts) {
-      if (scriptNode.src) {
-        // Load external script
-        const script = document.createElement('script');
-        script.src = scriptNode.src;
-        script.type = scriptNode.type || 'text/javascript';
-        this.shadowRoot.appendChild(script);
-      } else {
-        // Execute inline script with shadow DOM context (supports import and await)
-        await this.executeInlineScript(content);
-      }
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this._scriptContexts = new Map();
     }
     
-    // Clear stored scripts
-    this._scriptContexts.clear();
-  }
-  
-  async executeInlineScript(code) {
-    try {
-      // Create a unique context ID for this script execution
-      const contextId = `__htmlComponent_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-      
-      // Store context in a temporary global variable
-      window[contextId] = {
-        shadowRoot: this.shadowRoot,
-        component: this,
-        $: (selector) => this.shadowRoot.querySelector(selector),
-        $$: (selector) => this.shadowRoot.querySelectorAll(selector)
-      };
-      
-      // Resolve relative imports to absolute URLs
-      // This is necessary because blob URLs don't have a proper base for resolution
-      const resolvedCode = this.resolveImports(code);
-      
-      // Create a module script that retrieves the context
-      // This allows use of import and await
-      const moduleCode = `
+    static get observedAttributes() {
+        return ['src'];
+    }
+    
+    connectedCallback() {
+        const src = this.getAttribute('src');
+        if (src) {
+            this.load(src);
+        }
+    }
+    
+    async load(url) {
+        try {
+            const response = await fetch(url);
+            const html = await response.text();
+            
+            // Parse and process the template
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, 'text/html');
+            const com = doc.querySelector('html');
+            
+            if (!com) {
+                throw new Error('No component found');
+            }
+            
+            // Create a document fragment from template content
+            const fragment = document.createDocumentFragment();
+            const tempContainer = document.createElement('div');
+            tempContainer.innerHTML = com.innerHTML;
+            
+            // Process each node
+            this.processNodes(tempContainer, fragment);
+            
+            // Clear and append to shadow root
+            this.shadowRoot.innerHTML = '';
+            this.shadowRoot.appendChild(fragment);
+            
+            // Initialize any scripts after DOM is ready
+            await this.initializeScripts();
+            
+            // Fire loaded event
+            this.dispatchEvent(new CustomEvent('loaded', { 
+                detail: { url },
+                bubbles: true 
+            }));
+            
+        } catch (error) {
+            this.handleError(error);
+        }
+    }
+    
+    processNodes(source, target) {
+        Array.from(source.childNodes).forEach(node => {
+            if (node.nodeType === Node.ELEMENT_NODE) {
+                if (node.tagName === 'SCRIPT') {
+                    // Store script for later execution
+                    this._scriptContexts.set(node, node.textContent || node.src);
+                } else {
+                    // Clone and append other elements
+                    const cloned = node.cloneNode(true);
+                    target.appendChild(cloned);
+                }
+            } else {
+                // Clone text nodes and comments
+                target.appendChild(node.cloneNode(true));
+            }
+        });
+    }
+    
+    async initializeScripts() {
+        for (const [scriptNode, content] of this._scriptContexts) {
+            if (scriptNode.src) {
+                // Load external script
+                const script = document.createElement('script');
+                script.src = scriptNode.src;
+                script.type = scriptNode.type || 'text/javascript';
+                this.shadowRoot.appendChild(script);
+            } else {
+                // Execute inline script with shadow DOM context (supports import and await)
+                await this.executeInlineScript(content);
+            }
+        }
+        
+        // Clear stored scripts
+        this._scriptContexts.clear();
+    }
+    
+    async executeInlineScript(code) {
+        try {
+            // Create a unique context ID for this script execution
+            const contextId = `__htmlComponent_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+            
+            // Store context in a temporary global variable
+            window[contextId] = {
+                shadowRoot: this.shadowRoot,
+                component: this,
+                $: (selector) => this.shadowRoot.querySelector(selector),
+                $$: (selector) => this.shadowRoot.querySelectorAll(selector)
+            };
+            
+            // Resolve relative imports to absolute URLs
+            // This is necessary because blob URLs don't have a proper base for resolution
+            const resolvedCode = this.resolveImports(code);
+            
+            // Create a module script that retrieves the context
+            // This allows use of import and await
+            const moduleCode = `
         const { shadowRoot, component, $, $$ } = window['${contextId}'];
         
         // Clean up the global context immediately after retrieval
@@ -119,62 +119,62 @@ export class HTMLComponent extends HTMLElement {
         
         // Execute the original script (with import and await support)
         ${resolvedCode}
-      `;
-      
-      // Create a blob URL for the module
-      const blob = new Blob([moduleCode], { type: 'text/javascript' });
-      const url = URL.createObjectURL(blob);
-      
-      try {
-        // Import and execute as a module
-        await import(url);
-      } finally {
-        // Clean up the blob URL
-        URL.revokeObjectURL(url);
-        // Ensure context is cleaned up even if script fails
-        delete window[contextId];
-      }
-      
-    } catch (error) {
-      console.error('Script execution error:', error);
+            `;
+            
+            // Create a blob URL for the module
+            const blob = new Blob([moduleCode], { type: 'text/javascript' });
+            const url = URL.createObjectURL(blob);
+            
+            try {
+                // Import and execute as a module
+                await import(url);
+            } finally {
+                // Clean up the blob URL
+                URL.revokeObjectURL(url);
+                // Ensure context is cleaned up even if script fails
+                delete window[contextId];
+            }
+            
+        } catch (error) {
+            console.error('Script execution error:', error);
+        }
     }
-  }
-  
-  resolveImports(code) {
-    // Replace import statements with absolute URLs
-    // Matches: import ... from "path" or import ... from 'path'
-    return code.replace(
-      /import\s+(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)(?:\s*,\s*(?:\{[^}]*\}|\*\s+as\s+\w+|\w+))*\s+from\s+)?['"]([^'"]+)['"]/g,
-      (match, path) => {
-        // Convert relative paths to absolute URLs
-        const absoluteUrl = new URL(path, window.location.origin + window.location.pathname).href;
-        return match.replace(path, absoluteUrl);
-      }
-    );
-  }
-  
-  handleError(error) {
-    console.error('Component loading error:', error);
-    this.shadowRoot.innerHTML = `
+    
+    resolveImports(code) {
+        // Replace import statements with absolute URLs
+        // Matches: import ... from "path" or import ... from 'path'
+        return code.replace(
+            /import\s+(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)(?:\s*,\s*(?:\{[^}]*\}|\*\s+as\s+\w+|\w+))*\s+from\s+)?['"]([^'"]+)['"]/g,
+            (match, path) => {
+                // Convert relative paths to absolute URLs
+                const absoluteUrl = new URL(path, window.location.origin + window.location.pathname).href;
+                return match.replace(path, absoluteUrl);
+            }
+        );
+    }
+    
+    handleError(error) {
+        console.error('Component loading error:', error);
+        this.shadowRoot.innerHTML = `
       <div style="padding: 10px; background: #fee; color: #c00; border: 1px solid #c00; border-radius: 4px;">
         <strong>Error:</strong> ${error.message}
       </div>
-    `;
+        `;
+        
+        this.dispatchEvent(new CustomEvent('error', {
+            detail: { error },
+            bubbles: true
+        }));
+    }
     
-    this.dispatchEvent(new CustomEvent('error', {
-      detail: { error },
-      bubbles: true
-    }));
-  }
-  
-  // Utility methods for external access
-  getElement(selector) {
-    return this.shadowRoot.querySelector(selector);
-  }
-  
-  getElements(selector) {
-    return this.shadowRoot.querySelectorAll(selector);
-  }
+    // Utility methods for external access
+    getElement(selector) {
+        return this.shadowRoot.querySelector(selector);
+    }
+    
+    getElements(selector) {
+        return this.shadowRoot.querySelectorAll(selector);
+    }
 }
-  
+    
 customElements.define('html-component', HTMLComponent);

--- a/assets/signin.html
+++ b/assets/signin.html
@@ -1,38 +1,38 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <title>Apptron</title>
-    <link rel="stylesheet" href="styles.css" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <script type="module">
-        import { getAuth, authRedirect, clearAllCache, getBundle } from "/lib/apptron.js";
+  <meta charset="UTF-8">
+  <title>Apptron</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <script type="module">
+    import { getAuth, authRedirect, clearAllCache, getBundle } from "/lib/apptron.js";
 
-        const auth = await getAuth();
+    const auth = await getAuth();
 
-        auth.onSessionCreated(async () => {
-            const session = await auth.validateSession();
-            authRedirect("/dashboard", session.claims.username);
-        });
+    auth.onSessionCreated(async () => {
+      const session = await auth.validateSession();
+      authRedirect("/dashboard", session.claims.username);
+    });
 
-        // already signed in
-        auth.validatedSession.then(session => {
-            if (session.is_valid) {
-                authRedirect("/dashboard", session.claims.username);
-            }
-        });
+    // already signed in
+    auth.validatedSession.then(session => {
+      if (session.is_valid) {
+        authRedirect("/dashboard", session.claims.username);
+      }
+    });
 
-        // start pre-loading common bundles
-        // on sign-in clear the cache
-        await clearAllCache("assets");
-        await clearAllCache("bundles");
-        getBundle("/bundles/sys.tar.gz");
-        getBundle("/bundles/goroot.tar.br");
-        getBundle("/bundles/gocache-386.tar.br");
-    </script>
+    // start pre-loading common bundles
+    // on sign-in clear the cache
+    await clearAllCache("assets");
+    await clearAllCache("bundles");
+    getBundle("/bundles/sys.tar.gz");
+    getBundle("/bundles/goroot.tar.br");
+    getBundle("/bundles/gocache-386.tar.br");
+  </script>
 </head>
 
 <body>
-    <hanko-auth></hanko-auth>
+  <hanko-auth></hanko-auth>
 </body>
 </html>

--- a/assets/signin.html
+++ b/assets/signin.html
@@ -1,38 +1,38 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Apptron</title>
-  <link rel="stylesheet" href="styles.css" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <script type="module">
-    import { getAuth, authRedirect, clearAllCache, getBundle } from "/lib/apptron.js";
+    <meta charset="UTF-8">
+    <title>Apptron</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <script type="module">
+        import { getAuth, authRedirect, clearAllCache, getBundle } from "/lib/apptron.js";
 
-    const auth = await getAuth();
+        const auth = await getAuth();
 
-    auth.onSessionCreated(async () => {
-      const session = await auth.validateSession();
-      authRedirect("/dashboard", session.claims.username);
-    });
+        auth.onSessionCreated(async () => {
+            const session = await auth.validateSession();
+            authRedirect("/dashboard", session.claims.username);
+        });
 
-    // already signed in
-    auth.validatedSession.then(session => {
-      if (session.is_valid) {
-        authRedirect("/dashboard", session.claims.username);
-      }
-    });
+        // already signed in
+        auth.validatedSession.then(session => {
+            if (session.is_valid) {
+                authRedirect("/dashboard", session.claims.username);
+            }
+        });
 
-    // start pre-loading common bundles
-    // on sign-in clear the cache
-    await clearAllCache("assets");
-    await clearAllCache("bundles");
-    getBundle("/bundles/sys.tar.gz");
-    getBundle("/bundles/goroot.tar.br");
-    getBundle("/bundles/gocache-386.tar.br");
-  </script>
+        // start pre-loading common bundles
+        // on sign-in clear the cache
+        await clearAllCache("assets");
+        await clearAllCache("bundles");
+        getBundle("/bundles/sys.tar.gz");
+        getBundle("/bundles/goroot.tar.br");
+        getBundle("/bundles/gocache-386.tar.br");
+    </script>
 </head>
 
 <body>
-  <hanko-auth></hanko-auth>
+    <hanko-auth></hanko-auth>
 </body>
 </html>

--- a/assets/signout.html
+++ b/assets/signout.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <title>Apptron</title>
-    <link rel="stylesheet" href="styles.css" />
-    <script type="module">
-        import { getAuth, authRedirect } from "/lib/apptron.js";
-        const auth = await getAuth();
-        await auth.logout();
-        authRedirect("/");
-    </script>
+  <meta charset="UTF-8">
+  <title>Apptron</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script type="module">
+    import { getAuth, authRedirect } from "/lib/apptron.js";
+    const auth = await getAuth();
+    await auth.logout();
+    authRedirect("/");
+  </script>
 </head>
 <body>
 </body>

--- a/assets/signout.html
+++ b/assets/signout.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Apptron</title>
-  <link rel="stylesheet" href="styles.css" />
-  <script type="module">
-    import { getAuth, authRedirect } from "/lib/apptron.js";
-    const auth = await getAuth();
-    await auth.logout();
-    authRedirect("/");
-  </script>
+    <meta charset="UTF-8">
+    <title>Apptron</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script type="module">
+        import { getAuth, authRedirect } from "/lib/apptron.js";
+        const auth = await getAuth();
+        await auth.logout();
+        authRedirect("/");
+    </script>
 </head>
 <body>
 </body>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -118,20 +118,20 @@
 
 
 hanko-profile::part(headline1) {
-    font-size: 16px;
-    margin-bottom: 0px;
-    margin-top: 1.75rem;
+  font-size: 16px;
+  margin-bottom: 0px;
+  margin-top: 1.75rem;
 }
 .hanko_paragraph {
-    margin-top: 0px;
+  margin-top: 0px;
 }
 hanko-auth {
-    position: absolute;
-    top: 10vh;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 400px;
-    padding: 1rem;
+  position: absolute;
+  top: 10vh;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 400px;
+  padding: 1rem;
 }
 
 @keyframes button-loading-spinner {
@@ -168,43 +168,43 @@ p {
 }
 
 button, input, select, textarea {
-    font: inherit;
+  font: inherit;
 }
 
 /* Exclude workbench so its layout (e.g. .monaco-tl-twistie) uses default content-box */
 *:not(vscode-workbench *) {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 hidden {
-    display: none !important;
+  display: none !important;
 }
 
 label, legend {
-    color: var(--gray-100);
-    margin-bottom: var(--spacing);
+  color: var(--gray-100);
+  margin-bottom: var(--spacing);
 }
 input[type="text"], textarea, select {
-    border-radius: var(--border-radius);
-    border: 1px solid var(--gray-300);
-    background-color: inherit;
-    color: inherit;
-    padding: 0.5rem;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--gray-300);
+  background-color: inherit;
+  color: inherit;
+  padding: 0.5rem;
 }
 input:not([type="radio"]), button.primary, button.secondary {
-    height: var(--item-height);
+  height: var(--item-height);
 }
 input[type="text"]:focus,
 textarea:focus,
 button:focus,
 select:focus {
-    outline: none;
-    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2);
+  outline: none; 
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2);
 }
 input:disabled, textarea:disabled, select:disabled {
-    border: var(--gray-300);
-    cursor:not-allowed;
-    color: var(--gray-300);
+  border: var(--gray-300);
+  cursor:not-allowed;
+  color: var(--gray-300);
 }
 textarea:disabled {
     resize: none;
@@ -212,23 +212,23 @@ textarea:disabled {
 label:has(+ input:disabled),
 label:has(+ select:disabled),
 label:has(+ textarea:disabled) {
-    color: var(--gray-300);
+  color: var(--gray-300);
 }
 input:read-only#project-name {
     border: none;
     cursor:text;
 }
 .input-row {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing);
 }
 .input-row input {
-    flex: 1;
-    min-width: 0;
+  flex: 1; 
+  min-width: 0; 
 }
 .input-row button {
-    flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 .input-row > .icon-btn {
     font-size: var(--text-base);
@@ -249,7 +249,7 @@ button {
     padding: 0.6rem 1rem;
 }
 /* .btn is for all buttons that should look/behave like a button,
-even if they don't have a background color. includes menu items.
+even if they don't have a background color. includes menu items. 
 button.primary and button.secondary are a subset of .btn */
 .btn {
     border-radius: var(--border-radius);
@@ -304,8 +304,8 @@ button span {
     transition: all 0.2s;
 }
 .btn-loading span {
-    visibility: hidden;
-    opacity: 0;
+  visibility: hidden;
+  opacity: 0;
 }
 
 .dialog-close:hover {
@@ -315,62 +315,62 @@ button span {
 /* DASHBOARD ----------------- */
 
 .container {
-    padding: 2rem;
+  padding: 2rem;
 }
 
 header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
 }
 
 header h1 {
-    margin: 0;
-    font-size: 1.5rem;
+  margin: 0;
+  font-size: 1.5rem;
 }
 
 .projects-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
 }
 
 .no-projects {
-    color: var(--gray-100);
-    text-align: center;
-    font-style: italic;
-    margin: 2rem 0;
-    width: 100%;
+  color: var(--gray-100);
+  text-align: center;
+  font-style: italic;
+  margin: 2rem 0;
+  width: 100%;
 }
 
 .project-card {
-    background: var(--gray-600);
-    border: 1px solid var(--gray-500);
-    padding: 1.2rem;
-    border-radius: var(--border-radius);
-    flex: 0 1 calc((100% - 1.5rem) / 2); /* two-column layout */
-    min-width: 250px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    cursor: pointer;
+  background: var(--gray-600);
+  border: 1px solid var(--gray-500);
+  padding: 1.2rem;
+  border-radius: var(--border-radius);
+  flex: 0 1 calc((100% - 1.5rem) / 2); /* two-column layout */
+  min-width: 250px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  cursor: pointer;
 }
 
 .project-card .title {
-    margin: 0 0 0.3rem;
-    font-size: 1.1rem;
+  margin: 0 0 0.3rem;
+  font-size: 1.1rem;
 }
 
 .project-card .desc {
-    margin: 0 0 0.8rem;
-    font-size: 0.9rem;
-    color: var(--gray-100);
+  margin: 0 0 0.8rem;
+  font-size: 0.9rem;
+  color: var(--gray-100);
 }
 
 .project-card .time {
-    font-size: 0.8rem;
-    color: var(--gray-100);
+  font-size: 0.8rem;
+  color: var(--gray-100);
 }
 
 .card-header {
@@ -462,18 +462,18 @@ header h1 {
 }
 #header-bar #nav-links,
 #header-bar #header-left {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 #header-bar #header-left {
-    gap: 1rem;
+  gap: 1rem;
 }
 #header-bar #nav-links {
-    gap: 2rem;
+  gap: 2rem;
 }
 
 #header-bar .project-header button#edit-project {
-    padding: 0 0.25rem;
+  padding: 0 0.25rem;
 }
 
 /* TODO: fix button styling so that a plain button is the default,
@@ -482,10 +482,10 @@ and we won't need these selectors */
 #header-bar #nav-links > apptron-dropdown > button,
 #header-bar .project-header button,
 #header-bar #header-left > button {
-    cursor: pointer;
-    background-color: inherit;
-    color: inherit;
-    padding: 0;
+  cursor: pointer;
+  background-color: inherit;
+  color: inherit;
+  padding: 0;
 }
 
 #header-bar > #header-left > a {
@@ -495,42 +495,42 @@ and we won't need these selectors */
 #header-bar #nav-links > button:focus,
 #header-bar #nav-links > apptron-dropdown > button:focus,
 #header-bar .project-header button:focus {
-    box-shadow: none;
+  box-shadow: none;
 }
 #topbar {
-    height: 35px;
+  height: 35px;
 }
 .project-header.private .name::before {
-    content: "";
-    display: inline-block;
-    width: 1.1em; height: 1.1rem;
-    vertical-align: middle;
-    margin-right: 0.25rem;
-    background: currentColor;
-    -webkit-mask: url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13 7H12V5C12 3.93913 11.5786 2.92172 10.8284 2.17157C10.0783 1.42143 9.06087 1 8 1C6.93913 1 5.92172 1.42143 5.17157 2.17157C4.42143 2.92172 4 3.93913 4 5V7H3L2 8V14L3 15H13L14 14V8L13 7ZM5 5C5 4.20435 5.31607 3.44129 5.87868 2.87868C6.44129 2.31607 7.20435 2 8 2C8.79565 2 9.55871 2.31607 10.1213 2.87868C10.6839 3.44129 11 4.20435 11 5V7H5V5ZM13 14H3V8H13V14Z" fill="currentColor"/></svg>') no-repeat center / contain;
-    mask: url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13 7H12V5C12 3.93913 11.5786 2.92172 10.8284 2.17157C10.0783 1.42143 9.06087 1 8 1C6.93913 1 5.92172 1.42143 5.17157 2.17157C4.42143 2.92172 4 3.93913 4 5V7H3L2 8V14L3 15H13L14 14V8L13 7ZM5 5C5 4.20435 5.31607 3.44129 5.87868 2.87868C6.44129 2.31607 7.20435 2 8 2C8.79565 2 9.55871 2.31607 10.1213 2.87868C10.6839 3.44129 11 4.20435 11 5V7H5V5ZM13 14H3V8H13V14Z" fill="currentColor"/></svg>') no-repeat center / contain;
+  content: "";
+  display: inline-block;
+  width: 1.1em; height: 1.1rem;
+  vertical-align: middle;
+  margin-right: 0.25rem;
+  background: currentColor;
+  -webkit-mask: url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13 7H12V5C12 3.93913 11.5786 2.92172 10.8284 2.17157C10.0783 1.42143 9.06087 1 8 1C6.93913 1 5.92172 1.42143 5.17157 2.17157C4.42143 2.92172 4 3.93913 4 5V7H3L2 8V14L3 15H13L14 14V8L13 7ZM5 5C5 4.20435 5.31607 3.44129 5.87868 2.87868C6.44129 2.31607 7.20435 2 8 2C8.79565 2 9.55871 2.31607 10.1213 2.87868C10.6839 3.44129 11 4.20435 11 5V7H5V5ZM13 14H3V8H13V14Z" fill="currentColor"/></svg>') no-repeat center / contain;
+  mask: url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13 7H12V5C12 3.93913 11.5786 2.92172 10.8284 2.17157C10.0783 1.42143 9.06087 1 8 1C6.93913 1 5.92172 1.42143 5.17157 2.17157C4.42143 2.92172 4 3.93913 4 5V7H3L2 8V14L3 15H13L14 14V8L13 7ZM5 5C5 4.20435 5.31607 3.44129 5.87868 2.87868C6.44129 2.31607 7.20435 2 8 2C8.79565 2 9.55871 2.31607 10.1213 2.87868C10.6839 3.44129 11 4.20435 11 5V7H5V5ZM13 14H3V8H13V14Z" fill="currentColor"/></svg>') no-repeat center / contain;
 }
 
 /* Dialog Styles ---------------------------*/
 dialog#modal {
-    position: fixed !important;
-    left: 50%;
-    top: 80px !important;          /* distance from top */
-    transform: translateX(-50%);   /* only center horizontally */
-    font: inherit;
-    background-color: var(--gray-600);
-    border: 1px solid var(--gray-500);
-    border-radius: var(--border-radius);
-    padding: 0rem 3rem 2rem;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
-    color: #fff;
-    z-index: 1000;
-    pointer-events: auto !important;
-    width: 464px;
-    margin: 0;
+  position: fixed !important;
+  left: 50%;
+  top: 80px !important;          /* distance from top */
+  transform: translateX(-50%);   /* only center horizontally */
+  font: inherit;
+  background-color: var(--gray-600);
+  border: 1px solid var(--gray-500);
+  border-radius: var(--border-radius);
+  padding: 0rem 3rem 2rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  color: #fff;
+  z-index: 1000;
+  pointer-events: auto !important;
+  width: 464px;
+  margin: 0;
 }
 dialog#modal::backdrop {
-    background-color: rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0.6);
 }
 /* Dialog tabs --------------- */
 .dialog-tabs {
@@ -559,15 +559,15 @@ dialog#modal::backdrop {
 }
 
 .dialog-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-top: var(--size-2);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: var(--size-2);
 }
 #modal .dialog-header h2 {
-    margin: 0;
-    font-size: 24px;
-    padding: 0;
+  margin: 0;
+  font-size: 24px;
+  padding: 0;
 }
 
 .dialog-body > p {
@@ -581,42 +581,42 @@ dialog#modal::backdrop {
     background-color: var(--gray-500);
 }
 .dialog-body input[type=text],
-.dialog-body textarea,
+.dialog-body textarea, 
 .dialog-body label {
-    display: block;
-    width: 100%;
+  display: block;
+  width: 100%;
 }
 .dialog-body input[type="text"]:not(.input-row input[type="text"]),
 .dialog-body textarea,
 .dialog-body select,
 .dialog-body fieldset {
-    margin-bottom: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 .dialog-footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-    margin-top: 2rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 2rem;
 }
 
 /* Create project modal */
 /* === Visibility fieldset === */
 .visibility-group {
-    border: none;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0;
+  border: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
 }
 
 /* === Radio options === */
 .radio-option {
-    display: grid !important;
-    grid-template-columns: auto 1fr;
-    column-gap: 0.6rem;
-    row-gap: 0.25rem;
-    align-items: start;
-    border-radius: 6px;
+  display: grid !important;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.6rem;
+  row-gap: 0.25rem;
+  align-items: start;
+  border-radius: 6px;
 }
 .radio-option:hover {
     background-color: rgba(255, 255, 255, 0.05);
@@ -624,38 +624,38 @@ dialog#modal::backdrop {
 
 }
 .radio-option input[type="radio"] {
-    margin-top: 0.2rem; /* vertically aligns circle with title */
-    accent-color: #2e7aff; /* blue highlight */
-    cursor: pointer;
+  margin-top: 0.2rem; /* vertically aligns circle with title */
+  accent-color: #2e7aff; /* blue highlight */
+  cursor: pointer;
 }
 /* === Option text === */
 .option-title {
-    color: #fff;
+  color: #fff;
 }
 .option-help {
-    grid-column: 2;
-    font-size: 0.85rem;
-    color: var(--gray-100);
-    line-height: 1.3;
+  grid-column: 2;
+  font-size: 0.85rem;
+  color: var(--gray-100);
+  line-height: 1.3;
 }
 /* otherwise there's too much space between the close button and the dialog contents... */
 .auth-container {
-    margin-top: -1rem;
+  margin-top: -1rem;
 }
 /* Top bar login state */
 #logout, #account, #account-dropdown, #edit-project, #share {
-    display: none !important;
+  display: none !important;
 }
 .signedin #account,
 .signedin #logout,
 .signedin #account-dropdown {
-    display: block !important;
+  display: block !important;
 }
 .signedin #edit-project {
-    display: inline !important;
+  display: inline !important;
 }
 .signedin #signin {
-    display: none !important;
+  display: none !important;
 }
 .signedin.project #share {
     display: inline-flex !important;
@@ -663,101 +663,101 @@ dialog#modal::backdrop {
 
 /* Project header, if on project page state */
 .project-header {
-    display: none !important;
+  display: none !important;
 }
 .project .project-header {
-    display: flex !important;
-    gap: var(--size-2);
+  display: flex !important;
+  gap: var(--size-2);
 }
 
 /* Dashboard popover menu */
 .card-menu[popover] {
-    color: inherit;
-    font: inherit;
-    min-width: 150px;
-    padding: 0.5rem;
-    background: var(--gray-600);
-    border: 1px solid var(--gray-500);
-    border-radius: var(--border-radius);
-    box-shadow: 0 10px 30px rgba(0,0,0,0.45);
+  color: inherit;
+  font: inherit;
+  min-width: 150px;
+  padding: 0.5rem;
+  background: var(--gray-600);
+  border: 1px solid var(--gray-500);
+  border-radius: var(--border-radius);
+  box-shadow: 0 10px 30px rgba(0,0,0,0.45);
 }
 
 /* Menu items */
 .menu-item {
-    font: inherit;
-    color: inherit;
-    cursor: pointer;
-    display: block;
-    width: 100%;
-    text-align: left;
-    background: transparent;
-    border: 0;
-    border-radius: var(--border-radius);
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: var(--border-radius);
 }
 .card-menu .menu-item:hover { background: var(--gray-500); }
 .card-menu .menu-item.danger { color: #ffb4b4; }
 .card-menu .menu-item.danger:hover { background: rgba(255, 80, 80, 0.12); }
 
 #loader {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    max-width: 100%;
-    max-height: 100%;
-    margin: 0;
-    padding: 0;
-    border: none;
-    background: transparent;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    outline: none;
-    pointer-events: none;
-    font: inherit;
-    color: #fff;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  outline: none;
+  pointer-events: none;
+  font: inherit;
+  color: #fff;
 }
 
 #loader .spinner {
-    width: 200px;
-    height: 200px;
-    background-image: url("/img/loader.svg");
-    background-repeat: no-repeat;
-    background-size: contain;
-    background-position: center;
+  width: 200px;
+  height: 200px;
+  background-image: url("/img/loader.svg");
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center;
 }
 
 #loader.fade-out, #loader.fade-out::backdrop {
-    animation: fadeOut 0.2s ease forwards;
+  animation: fadeOut 0.2s ease forwards;
 }
 
 #loader > * {
-    pointer-events: none;
-    user-select: none;
+  pointer-events: none;
+  user-select: none;
 }
 
 
 #loader::backdrop {
-    background-color: var(--gray-700);
+  background-color: var(--gray-700);
 }
 
 @keyframes fadeOut {
-    from {
-        opacity: 1;
-    }
-    to {
-        opacity: 0;
-    }
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 /* temp fixes to be done the "right" way */
 .form-error {
-    color: var(--error-color);
-    font-size: 0.85rem;
-    position: absolute;
-    margin-top: -1.25rem; /* placement hack */
+  color: var(--error-color);
+  font-size: 0.85rem;
+  position: absolute;
+  margin-top: -1.25rem; /* placement hack */
 }
 .form-error.is-info {
     color: var(--gray-100);

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -118,20 +118,20 @@
 
 
 hanko-profile::part(headline1) {
-  font-size: 16px;
-  margin-bottom: 0px;
-  margin-top: 1.75rem;
+    font-size: 16px;
+    margin-bottom: 0px;
+    margin-top: 1.75rem;
 }
 .hanko_paragraph {
-  margin-top: 0px;
+    margin-top: 0px;
 }
 hanko-auth {
-  position: absolute;
-  top: 10vh;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 400px;
-  padding: 1rem;
+    position: absolute;
+    top: 10vh;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 400px;
+    padding: 1rem;
 }
 
 @keyframes button-loading-spinner {
@@ -168,43 +168,43 @@ p {
 }
 
 button, input, select, textarea {
-  font: inherit;
+    font: inherit;
 }
 
 /* Exclude workbench so its layout (e.g. .monaco-tl-twistie) uses default content-box */
 *:not(vscode-workbench *) {
-  box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 hidden {
-  display: none !important;
+    display: none !important;
 }
 
 label, legend {
-  color: var(--gray-100);
-  margin-bottom: var(--spacing);
+    color: var(--gray-100);
+    margin-bottom: var(--spacing);
 }
 input[type="text"], textarea, select {
-  border-radius: var(--border-radius);
-  border: 1px solid var(--gray-300);
-  background-color: inherit;
-  color: inherit;
-  padding: 0.5rem;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--gray-300);
+    background-color: inherit;
+    color: inherit;
+    padding: 0.5rem;
 }
 input:not([type="radio"]), button.primary, button.secondary {
-  height: var(--item-height);
+    height: var(--item-height);
 }
 input[type="text"]:focus,
 textarea:focus,
 button:focus,
 select:focus {
-  outline: none; 
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2);
+    outline: none;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2);
 }
 input:disabled, textarea:disabled, select:disabled {
-  border: var(--gray-300);
-  cursor:not-allowed;
-  color: var(--gray-300);
+    border: var(--gray-300);
+    cursor:not-allowed;
+    color: var(--gray-300);
 }
 textarea:disabled {
     resize: none;
@@ -212,23 +212,23 @@ textarea:disabled {
 label:has(+ input:disabled),
 label:has(+ select:disabled),
 label:has(+ textarea:disabled) {
-  color: var(--gray-300);
+    color: var(--gray-300);
 }
 input:read-only#project-name {
     border: none;
     cursor:text;
 }
 .input-row {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing);
+    display: flex;
+    align-items: center;
+    gap: var(--spacing);
 }
 .input-row input {
-  flex: 1; 
-  min-width: 0; 
+    flex: 1;
+    min-width: 0;
 }
 .input-row button {
-  flex: 0 0 auto;
+    flex: 0 0 auto;
 }
 .input-row > .icon-btn {
     font-size: var(--text-base);
@@ -249,7 +249,7 @@ button {
     padding: 0.6rem 1rem;
 }
 /* .btn is for all buttons that should look/behave like a button,
-even if they don't have a background color. includes menu items. 
+even if they don't have a background color. includes menu items.
 button.primary and button.secondary are a subset of .btn */
 .btn {
     border-radius: var(--border-radius);
@@ -304,8 +304,8 @@ button span {
     transition: all 0.2s;
 }
 .btn-loading span {
-  visibility: hidden;
-  opacity: 0;
+    visibility: hidden;
+    opacity: 0;
 }
 
 .dialog-close:hover {
@@ -315,62 +315,62 @@ button span {
 /* DASHBOARD ----------------- */
 
 .container {
-  padding: 2rem;
+    padding: 2rem;
 }
 
 header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2rem;
 }
 
 header h1 {
-  margin: 0;
-  font-size: 1.5rem;
+    margin: 0;
+    font-size: 1.5rem;
 }
 
 .projects-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
 }
 
 .no-projects {
-  color: var(--gray-100);
-  text-align: center;
-  font-style: italic;
-  margin: 2rem 0;
-  width: 100%;
+    color: var(--gray-100);
+    text-align: center;
+    font-style: italic;
+    margin: 2rem 0;
+    width: 100%;
 }
 
 .project-card {
-  background: var(--gray-600);
-  border: 1px solid var(--gray-500);
-  padding: 1.2rem;
-  border-radius: var(--border-radius);
-  flex: 0 1 calc((100% - 1.5rem) / 2); /* two-column layout */
-  min-width: 250px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  cursor: pointer;
+    background: var(--gray-600);
+    border: 1px solid var(--gray-500);
+    padding: 1.2rem;
+    border-radius: var(--border-radius);
+    flex: 0 1 calc((100% - 1.5rem) / 2); /* two-column layout */
+    min-width: 250px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    cursor: pointer;
 }
 
 .project-card .title {
-  margin: 0 0 0.3rem;
-  font-size: 1.1rem;
+    margin: 0 0 0.3rem;
+    font-size: 1.1rem;
 }
 
 .project-card .desc {
-  margin: 0 0 0.8rem;
-  font-size: 0.9rem;
-  color: var(--gray-100);
+    margin: 0 0 0.8rem;
+    font-size: 0.9rem;
+    color: var(--gray-100);
 }
 
 .project-card .time {
-  font-size: 0.8rem;
-  color: var(--gray-100);
+    font-size: 0.8rem;
+    color: var(--gray-100);
 }
 
 .card-header {
@@ -462,18 +462,18 @@ header h1 {
 }
 #header-bar #nav-links,
 #header-bar #header-left {
-  display: flex;
-  align-items: center;
+    display: flex;
+    align-items: center;
 }
 #header-bar #header-left {
-  gap: 1rem;
+    gap: 1rem;
 }
 #header-bar #nav-links {
-  gap: 2rem;
+    gap: 2rem;
 }
 
 #header-bar .project-header button#edit-project {
-  padding: 0 0.25rem;
+    padding: 0 0.25rem;
 }
 
 /* TODO: fix button styling so that a plain button is the default,
@@ -482,10 +482,10 @@ and we won't need these selectors */
 #header-bar #nav-links > apptron-dropdown > button,
 #header-bar .project-header button,
 #header-bar #header-left > button {
-  cursor: pointer;
-  background-color: inherit;
-  color: inherit;
-  padding: 0;
+    cursor: pointer;
+    background-color: inherit;
+    color: inherit;
+    padding: 0;
 }
 
 #header-bar > #header-left > a {
@@ -495,42 +495,42 @@ and we won't need these selectors */
 #header-bar #nav-links > button:focus,
 #header-bar #nav-links > apptron-dropdown > button:focus,
 #header-bar .project-header button:focus {
-  box-shadow: none;
+    box-shadow: none;
 }
 #topbar {
-  height: 35px;
+    height: 35px;
 }
 .project-header.private .name::before {
-  content: "";
-  display: inline-block;
-  width: 1.1em; height: 1.1rem;
-  vertical-align: middle;
-  margin-right: 0.25rem;
-  background: currentColor;
-  -webkit-mask: url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13 7H12V5C12 3.93913 11.5786 2.92172 10.8284 2.17157C10.0783 1.42143 9.06087 1 8 1C6.93913 1 5.92172 1.42143 5.17157 2.17157C4.42143 2.92172 4 3.93913 4 5V7H3L2 8V14L3 15H13L14 14V8L13 7ZM5 5C5 4.20435 5.31607 3.44129 5.87868 2.87868C6.44129 2.31607 7.20435 2 8 2C8.79565 2 9.55871 2.31607 10.1213 2.87868C10.6839 3.44129 11 4.20435 11 5V7H5V5ZM13 14H3V8H13V14Z" fill="currentColor"/></svg>') no-repeat center / contain;
-  mask: url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13 7H12V5C12 3.93913 11.5786 2.92172 10.8284 2.17157C10.0783 1.42143 9.06087 1 8 1C6.93913 1 5.92172 1.42143 5.17157 2.17157C4.42143 2.92172 4 3.93913 4 5V7H3L2 8V14L3 15H13L14 14V8L13 7ZM5 5C5 4.20435 5.31607 3.44129 5.87868 2.87868C6.44129 2.31607 7.20435 2 8 2C8.79565 2 9.55871 2.31607 10.1213 2.87868C10.6839 3.44129 11 4.20435 11 5V7H5V5ZM13 14H3V8H13V14Z" fill="currentColor"/></svg>') no-repeat center / contain;
+    content: "";
+    display: inline-block;
+    width: 1.1em; height: 1.1rem;
+    vertical-align: middle;
+    margin-right: 0.25rem;
+    background: currentColor;
+    -webkit-mask: url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13 7H12V5C12 3.93913 11.5786 2.92172 10.8284 2.17157C10.0783 1.42143 9.06087 1 8 1C6.93913 1 5.92172 1.42143 5.17157 2.17157C4.42143 2.92172 4 3.93913 4 5V7H3L2 8V14L3 15H13L14 14V8L13 7ZM5 5C5 4.20435 5.31607 3.44129 5.87868 2.87868C6.44129 2.31607 7.20435 2 8 2C8.79565 2 9.55871 2.31607 10.1213 2.87868C10.6839 3.44129 11 4.20435 11 5V7H5V5ZM13 14H3V8H13V14Z" fill="currentColor"/></svg>') no-repeat center / contain;
+    mask: url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13 7H12V5C12 3.93913 11.5786 2.92172 10.8284 2.17157C10.0783 1.42143 9.06087 1 8 1C6.93913 1 5.92172 1.42143 5.17157 2.17157C4.42143 2.92172 4 3.93913 4 5V7H3L2 8V14L3 15H13L14 14V8L13 7ZM5 5C5 4.20435 5.31607 3.44129 5.87868 2.87868C6.44129 2.31607 7.20435 2 8 2C8.79565 2 9.55871 2.31607 10.1213 2.87868C10.6839 3.44129 11 4.20435 11 5V7H5V5ZM13 14H3V8H13V14Z" fill="currentColor"/></svg>') no-repeat center / contain;
 }
 
 /* Dialog Styles ---------------------------*/
 dialog#modal {
-  position: fixed !important;
-  left: 50%;
-  top: 80px !important;          /* distance from top */
-  transform: translateX(-50%);   /* only center horizontally */
-  font: inherit;
-  background-color: var(--gray-600);
-  border: 1px solid var(--gray-500);
-  border-radius: var(--border-radius);
-  padding: 0rem 3rem 2rem;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
-  color: #fff;
-  z-index: 1000;
-  pointer-events: auto !important;
-  width: 464px;
-  margin: 0;
+    position: fixed !important;
+    left: 50%;
+    top: 80px !important;          /* distance from top */
+    transform: translateX(-50%);   /* only center horizontally */
+    font: inherit;
+    background-color: var(--gray-600);
+    border: 1px solid var(--gray-500);
+    border-radius: var(--border-radius);
+    padding: 0rem 3rem 2rem;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+    color: #fff;
+    z-index: 1000;
+    pointer-events: auto !important;
+    width: 464px;
+    margin: 0;
 }
 dialog#modal::backdrop {
-  background-color: rgba(0, 0, 0, 0.6);
+    background-color: rgba(0, 0, 0, 0.6);
 }
 /* Dialog tabs --------------- */
 .dialog-tabs {
@@ -559,15 +559,15 @@ dialog#modal::backdrop {
 }
 
 .dialog-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: var(--size-2);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: var(--size-2);
 }
 #modal .dialog-header h2 {
-  margin: 0;
-  font-size: 24px;
-  padding: 0;
+    margin: 0;
+    font-size: 24px;
+    padding: 0;
 }
 
 .dialog-body > p {
@@ -581,42 +581,42 @@ dialog#modal::backdrop {
     background-color: var(--gray-500);
 }
 .dialog-body input[type=text],
-.dialog-body textarea, 
+.dialog-body textarea,
 .dialog-body label {
-  display: block;
-  width: 100%;
+    display: block;
+    width: 100%;
 }
 .dialog-body input[type="text"]:not(.input-row input[type="text"]),
 .dialog-body textarea,
 .dialog-body select,
 .dialog-body fieldset {
-  margin-bottom: 1.5rem;
+    margin-bottom: 1.5rem;
 }
 .dialog-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
-  margin-top: 2rem;
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 2rem;
 }
 
 /* Create project modal */
 /* === Visibility fieldset === */
 .visibility-group {
-  border: none;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
+    border: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
 }
 
 /* === Radio options === */
 .radio-option {
-  display: grid !important;
-  grid-template-columns: auto 1fr;
-  column-gap: 0.6rem;
-  row-gap: 0.25rem;
-  align-items: start;
-  border-radius: 6px;
+    display: grid !important;
+    grid-template-columns: auto 1fr;
+    column-gap: 0.6rem;
+    row-gap: 0.25rem;
+    align-items: start;
+    border-radius: 6px;
 }
 .radio-option:hover {
     background-color: rgba(255, 255, 255, 0.05);
@@ -624,38 +624,38 @@ dialog#modal::backdrop {
 
 }
 .radio-option input[type="radio"] {
-  margin-top: 0.2rem; /* vertically aligns circle with title */
-  accent-color: #2e7aff; /* blue highlight */
-  cursor: pointer;
+    margin-top: 0.2rem; /* vertically aligns circle with title */
+    accent-color: #2e7aff; /* blue highlight */
+    cursor: pointer;
 }
 /* === Option text === */
 .option-title {
-  color: #fff;
+    color: #fff;
 }
 .option-help {
-  grid-column: 2;
-  font-size: 0.85rem;
-  color: var(--gray-100);
-  line-height: 1.3;
+    grid-column: 2;
+    font-size: 0.85rem;
+    color: var(--gray-100);
+    line-height: 1.3;
 }
 /* otherwise there's too much space between the close button and the dialog contents... */
 .auth-container {
-  margin-top: -1rem;
+    margin-top: -1rem;
 }
 /* Top bar login state */
 #logout, #account, #account-dropdown, #edit-project, #share {
-  display: none !important;
+    display: none !important;
 }
 .signedin #account,
 .signedin #logout,
 .signedin #account-dropdown {
-  display: block !important;
+    display: block !important;
 }
 .signedin #edit-project {
-  display: inline !important;
+    display: inline !important;
 }
 .signedin #signin {
-  display: none !important;
+    display: none !important;
 }
 .signedin.project #share {
     display: inline-flex !important;
@@ -663,101 +663,101 @@ dialog#modal::backdrop {
 
 /* Project header, if on project page state */
 .project-header {
-  display: none !important;
+    display: none !important;
 }
 .project .project-header {
-  display: flex !important;
-  gap: var(--size-2);
+    display: flex !important;
+    gap: var(--size-2);
 }
 
 /* Dashboard popover menu */
 .card-menu[popover] {
-  color: inherit;
-  font: inherit;
-  min-width: 150px;
-  padding: 0.5rem;
-  background: var(--gray-600);
-  border: 1px solid var(--gray-500);
-  border-radius: var(--border-radius);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.45);
+    color: inherit;
+    font: inherit;
+    min-width: 150px;
+    padding: 0.5rem;
+    background: var(--gray-600);
+    border: 1px solid var(--gray-500);
+    border-radius: var(--border-radius);
+    box-shadow: 0 10px 30px rgba(0,0,0,0.45);
 }
 
 /* Menu items */
 .menu-item {
-  font: inherit;
-  color: inherit;
-  cursor: pointer;
-  display: block;
-  width: 100%;
-  text-align: left;
-  background: transparent;
-  border: 0;
-  border-radius: var(--border-radius);
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    display: block;
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: 0;
+    border-radius: var(--border-radius);
 }
 .card-menu .menu-item:hover { background: var(--gray-500); }
 .card-menu .menu-item.danger { color: #ffb4b4; }
 .card-menu .menu-item.danger:hover { background: rgba(255, 80, 80, 0.12); }
 
 #loader {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  max-height: 100%;
-  margin: 0;
-  padding: 0;
-  border: none;
-  background: transparent;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  outline: none;
-  pointer-events: none;
-  font: inherit;
-  color: #fff;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    outline: none;
+    pointer-events: none;
+    font: inherit;
+    color: #fff;
 }
 
 #loader .spinner {
-  width: 200px;
-  height: 200px;
-  background-image: url("/img/loader.svg");
-  background-repeat: no-repeat;
-  background-size: contain;
-  background-position: center;
+    width: 200px;
+    height: 200px;
+    background-image: url("/img/loader.svg");
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-position: center;
 }
 
 #loader.fade-out, #loader.fade-out::backdrop {
-  animation: fadeOut 0.2s ease forwards;
+    animation: fadeOut 0.2s ease forwards;
 }
 
 #loader > * {
-  pointer-events: none;
-  user-select: none;
+    pointer-events: none;
+    user-select: none;
 }
 
 
 #loader::backdrop {
-  background-color: var(--gray-700);
+    background-color: var(--gray-700);
 }
 
 @keyframes fadeOut {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
 }
 
 /* temp fixes to be done the "right" way */
 .form-error {
-  color: var(--error-color);
-  font-size: 0.85rem;
-  position: absolute;
-  margin-top: -1.25rem; /* placement hack */
+    color: var(--error-color);
+    font-size: 0.85rem;
+    position: absolute;
+    margin-top: -1.25rem; /* placement hack */
 }
 .form-error.is-info {
     color: var(--gray-100);

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -3,12 +3,12 @@ import * as fs from 'fs';
 import { addFileViaTerminal } from './helpers';
 
 function getProjectUrl(): string {
-  return JSON.parse(fs.readFileSync('.auth/test-project.json', 'utf-8')).url;
+    return JSON.parse(fs.readFileSync('.auth/test-project.json', 'utf-8')).url;
 }
 
 function getProjectName(): string {
-  const url = getProjectUrl();
-  return new URL(url).pathname.split('/edit/')[1];
+    const url = getProjectUrl();
+    return new URL(url).pathname.split('/edit/')[1];
 }
 
 // By the time these tests run, setup.ts has already created a test account
@@ -18,139 +18,139 @@ function getProjectName(): string {
 
 test.describe('Authenticated user', () => {
 
-  test('lands on the dashboard after sign in', async ({ page }) => {
-    await page.goto('/dashboard');
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible();
-  });
+    test('lands on the dashboard after sign in', async ({ page }) => {
+        await page.goto('/dashboard');
+        await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible();
+    });
 
-  test('can run a terminal command and see the result in the file explorer', async ({ page }) => {
-    await page.goto(getProjectUrl());
+    test('can run a terminal command and see the result in the file explorer', async ({ page }) => {
+        await page.goto(getProjectUrl());
 
-    const editor = page.frameLocator('iframe');
+        const editor = page.frameLocator('iframe');
 
-    // wait for VS Code to mount and the explorer toolbar to be ready
-    await editor.locator('.monaco-workbench').waitFor({ state: 'attached', timeout: 60000 });
-    await editor.locator('[aria-label="Refresh Explorer"]').first().waitFor({ state: 'visible', timeout: 30000 });
+        // wait for VS Code to mount and the explorer toolbar to be ready
+        await editor.locator('.monaco-workbench').waitFor({ state: 'attached', timeout: 60000 });
+        await editor.locator('[aria-label="Refresh Explorer"]').first().waitFor({ state: 'visible', timeout: 30000 });
 
-    await addFileViaTerminal(page, editor, 'hello.txt');
-  });
+        await addFileViaTerminal(page, editor, 'hello.txt');
+    });
 
-  test('can change project visibility to public via the dashboard context menu', async ({ page, browser }) => {
-    await page.goto('/dashboard');
+    test('can change project visibility to public via the dashboard context menu', async ({ page, browser }) => {
+        await page.goto('/dashboard');
 
-    // wait for session and projects to load
-    await page.locator('#header-bar.signedin').waitFor({ state: 'visible', timeout: 15000 });
-    await page.waitForFunction(() => customElements.get('html-component') !== undefined);
+        // wait for session and projects to load
+        await page.locator('#header-bar.signedin').waitFor({ state: 'visible', timeout: 15000 });
+        await page.waitForFunction(() => customElements.get('html-component') !== undefined);
 
-    // find the project card and open its context menu
-    const card = page.locator('.project-card', { hasText: getProjectName() });
-    await card.waitFor({ state: 'visible', timeout: 30000 });
-    await card.locator('.ellipsis-btn').click();
+        // find the project card and open its context menu
+        const card = page.locator('.project-card', { hasText: getProjectName() });
+        await card.waitFor({ state: 'visible', timeout: 30000 });
+        await card.locator('.ellipsis-btn').click();
 
-    // click Edit Settings
-    await card.getByRole('menuitem', { name: 'Edit Settings' }).click();
+        // click Edit Settings
+        await card.getByRole('menuitem', { name: 'Edit Settings' }).click();
 
-    // select Public visibility and save
-    await page.locator('#vis-public').check();
-    await expect(page.locator('#project-submit')).toBeEnabled({ timeout: 10000 });
-    await page.locator('#project-submit').click();
+        // select Public visibility and save
+        await page.locator('#vis-public').check();
+        await expect(page.locator('#project-submit')).toBeEnabled({ timeout: 10000 });
+        await page.locator('#project-submit').click();
 
-    // click the project card to open the editor
-    await card.click();
-    await page.waitForURL('**/edit/**', { timeout: 15000 });
+        // click the project card to open the editor
+        await card.click();
+        await page.waitForURL('**/edit/**', { timeout: 15000 });
 
-    // wait for VS Code and the explorer toolbar to be ready
-    const env = page.frameLocator('iframe');
-    await env.locator('.monaco-workbench').waitFor({ state: 'attached', timeout: 60000 });
-    await env.locator('[aria-label="Refresh Explorer"]').first().waitFor({ state: 'visible', timeout: 30000 });
+        // wait for VS Code and the explorer toolbar to be ready
+        const env = page.frameLocator('iframe');
+        await env.locator('.monaco-workbench').waitFor({ state: 'attached', timeout: 60000 });
+        await env.locator('[aria-label="Refresh Explorer"]').first().waitFor({ state: 'visible', timeout: 30000 });
 
-    // create a text file via the terminal
-    await addFileViaTerminal(page, env, 'hello.txt');
+        // create a text file via the terminal
+        await addFileViaTerminal(page, env, 'hello.txt');
 
-    // open the Share modal — #share is inside the env iframe
-    await env.locator('#share').click();
-    await expect(env.locator('#share-url')).toBeVisible({ timeout: 10000 });
+        // open the Share modal — #share is inside the env iframe
+        await env.locator('#share').click();
+        await expect(env.locator('#share-url')).toBeVisible({ timeout: 10000 });
 
-    // read the share URL from the input
-    const shareUrl = await env.locator('#share-url').inputValue();
+        // read the share URL from the input
+        const shareUrl = await env.locator('#share-url').inputValue();
 
-    // open a fresh browser session (no auth) and navigate to the share URL
-    console.log('[test] opening public browser session, share URL:', shareUrl);
-    const publicContext = await browser.newContext();
-    const publicPage = await publicContext.newPage();
-    await publicPage.goto(shareUrl);
-    await publicPage.waitForURL(shareUrl, { timeout: 15000 });
+        // open a fresh browser session (no auth) and navigate to the share URL
+        console.log('[test] opening public browser session, share URL:', shareUrl);
+        const publicContext = await browser.newContext();
+        const publicPage = await publicContext.newPage();
+        await publicPage.goto(shareUrl);
+        await publicPage.waitForURL(shareUrl, { timeout: 15000 });
 
-    // wait for VS Code and the file explorer to load in the public session
-    const publicEnv = publicPage.frameLocator('iframe');
-    await publicEnv.locator('.monaco-workbench').waitFor({ state: 'attached', timeout: 60000 });
-    await publicEnv.locator('[aria-label="Refresh Explorer"]').first().waitFor({ state: 'visible', timeout: 30000 });
-    await publicPage.waitForTimeout(5000);
+        // wait for VS Code and the file explorer to load in the public session
+        const publicEnv = publicPage.frameLocator('iframe');
+        await publicEnv.locator('.monaco-workbench').waitFor({ state: 'attached', timeout: 60000 });
+        await publicEnv.locator('[aria-label="Refresh Explorer"]').first().waitFor({ state: 'visible', timeout: 30000 });
+        await publicPage.waitForTimeout(5000);
 
-    await publicContext.close();
-  });
+        await publicContext.close();
+    });
 
-  test('private project returns 404 for anonymous users', async ({ page, browser }) => {
-    await page.goto('/dashboard');
-    await page.locator('#header-bar.signedin').waitFor({ state: 'visible', timeout: 15000 });
-    await page.waitForFunction(() => customElements.get('html-component') !== undefined);
+    test('private project returns 404 for anonymous users', async ({ page, browser }) => {
+        await page.goto('/dashboard');
+        await page.locator('#header-bar.signedin').waitFor({ state: 'visible', timeout: 15000 });
+        await page.waitForFunction(() => customElements.get('html-component') !== undefined);
 
-    // open settings and set visibility to private
-    const card = page.locator('.project-card', { hasText: getProjectName() });
-    await card.waitFor({ state: 'visible', timeout: 30000 });
-    await card.locator('.ellipsis-btn').click();
-    await card.getByRole('menuitem', { name: 'Edit Settings' }).click();
-    await page.locator('#vis-private').check();
-    await expect(page.locator('#vis-private')).toBeChecked();
-    await expect(page.locator('#project-submit')).toBeEnabled({ timeout: 10000 });
-    await page.locator('#project-submit').click();
+        // open settings and set visibility to private
+        const card = page.locator('.project-card', { hasText: getProjectName() });
+        await card.waitFor({ state: 'visible', timeout: 30000 });
+        await card.locator('.ellipsis-btn').click();
+        await card.getByRole('menuitem', { name: 'Edit Settings' }).click();
+        await page.locator('#vis-private').check();
+        await expect(page.locator('#vis-private')).toBeChecked();
+        await expect(page.locator('#project-submit')).toBeEnabled({ timeout: 10000 });
+        await page.locator('#project-submit').click();
 
-    // open the editor and verify the share URL is hidden when project is private
-    await card.click();
-    await page.waitForURL('**/edit/**', { timeout: 15000 });
-    const env = page.frameLocator('iframe');
-    await env.locator('.monaco-workbench').waitFor({ state: 'attached', timeout: 60000 });
-    await env.locator('[aria-label="Refresh Explorer"]').first().waitFor({ state: 'visible', timeout: 30000 });
-    await env.locator('#share').click();
-    await expect(env.locator('#share-block')).toHaveAttribute('hidden');
-    await page.goBack();
-    await page.waitForURL('**/dashboard**', { timeout: 15000 });
+        // open the editor and verify the share URL is hidden when project is private
+        await card.click();
+        await page.waitForURL('**/edit/**', { timeout: 15000 });
+        const env = page.frameLocator('iframe');
+        await env.locator('.monaco-workbench').waitFor({ state: 'attached', timeout: 60000 });
+        await env.locator('[aria-label="Refresh Explorer"]').first().waitFor({ state: 'visible', timeout: 30000 });
+        await env.locator('#share').click();
+        await expect(env.locator('#share-block')).toHaveAttribute('hidden');
+        await page.goBack();
+        await page.waitForURL('**/dashboard**', { timeout: 15000 });
 
-    // open the project URL in a fresh anonymous session and expect a 404
-    const editUrl = new URL(getProjectUrl());
-    editUrl.search = '';
-    console.log('[test] checking anonymous access to private project:', editUrl.toString());
-    const publicContext = await browser.newContext();
-    const publicPage = await publicContext.newPage();
-    const response = await publicPage.goto(editUrl.toString());
-    expect(response?.status()).toBe(404);
-    await publicContext.close();
-  });
+        // open the project URL in a fresh anonymous session and expect a 404
+        const editUrl = new URL(getProjectUrl());
+        editUrl.search = '';
+        console.log('[test] checking anonymous access to private project:', editUrl.toString());
+        const publicContext = await browser.newContext();
+        const publicPage = await publicContext.newPage();
+        const response = await publicPage.goto(editUrl.toString());
+        expect(response?.status()).toBe(404);
+        await publicContext.close();
+    });
 
-//   test('can create a project and see the editor loading', async ({ page }) => {
-//     await page.goto('/dashboard');
+//     test('can create a project and see the editor loading', async ({ page }) => {
+//         await page.goto('/dashboard');
 
-//     // wait for session and html-component custom element to be registered
-//     await page.locator('#header-bar.signedin').waitFor({ state: 'visible' });
-//     await page.waitForFunction(() => customElements.get('html-component') !== undefined);
+//         // wait for session and html-component custom element to be registered
+//         await page.locator('#header-bar.signedin').waitFor({ state: 'visible' });
+//         await page.waitForFunction(() => customElements.get('html-component') !== undefined);
 
-//     // click create project button and wait for modal
-//     await page.getByRole('button', { name: 'Create Project' }).click();
-//     await expect(page.getByRole('heading', { name: 'New Project' })).toBeVisible({ timeout: 30000 });
+//         // click create project button and wait for modal
+//         await page.getByRole('button', { name: 'Create Project' }).click();
+//         await expect(page.getByRole('heading', { name: 'New Project' })).toBeVisible({ timeout: 30000 });
 
-//     // set a unique name per project
-//     const projectName = `project${Date.now()}`;
-//     await page.getByLabel('Project name').fill(projectName);
+//         // set a unique name per project
+//         const projectName = `project${Date.now()}`;
+//         await page.getByLabel('Project name').fill(projectName);
 
-//     // wait for duplicate name check
-//     await expect(page.locator('#project-submit')).toBeEnabled({ timeout: 15000 });
-//     await page.locator('#project-submit').click();
+//         // wait for duplicate name check
+//         await expect(page.locator('#project-submit')).toBeEnabled({ timeout: 15000 });
+//         await page.locator('#project-submit').click();
 
-//     // wait for editor redirect
-//     await page.waitForURL('**/edit/**', { timeout: 15000 });
+//         // wait for editor redirect
+//         await page.waitForURL('**/edit/**', { timeout: 15000 });
 
-//     // wait for VS Code to mount — wb.create() injects .monaco-workbench into <vscode-workbench>
-//     await page.frameLocator('iframe').locator('.monaco-workbench').waitFor({ state: 'attached', timeout: 60000 });
-//   });
+//         // wait for VS Code to mount — wb.create() injects .monaco-workbench into <vscode-workbench>
+//         await page.frameLocator('iframe').locator('.monaco-workbench').waitFor({ state: 'attached', timeout: 60000 });
+//     });
 
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,24 +1,24 @@
 import { expect, Page, FrameLocator } from '@playwright/test';
 
 export async function createProject(page: Page): Promise<string> {
-  await page.goto('/dashboard');
-  await page.locator('#header-bar.signedin').waitFor({ state: 'visible', timeout: 15000 });
-  await page.waitForFunction(() => customElements.get('html-component') !== undefined);
-  await page.getByRole('button', { name: 'Create Project' }).click();
-  await page.getByRole('heading', { name: 'New Project' }).waitFor({ state: 'visible', timeout: 30000 });
-  const projectName = `project${Date.now()}`;
-  await page.getByLabel('Project name').fill(projectName);
-  await expect(page.locator('#project-submit')).toBeEnabled({ timeout: 15000 });
-  await page.locator('#project-submit').click();
-  await page.waitForURL('**/edit/**', { timeout: 15000 });
-  return page.url();
+    await page.goto('/dashboard');
+    await page.locator('#header-bar.signedin').waitFor({ state: 'visible', timeout: 15000 });
+    await page.waitForFunction(() => customElements.get('html-component') !== undefined);
+    await page.getByRole('button', { name: 'Create Project' }).click();
+    await page.getByRole('heading', { name: 'New Project' }).waitFor({ state: 'visible', timeout: 30000 });
+    const projectName = `project${Date.now()}`;
+    await page.getByLabel('Project name').fill(projectName);
+    await expect(page.locator('#project-submit')).toBeEnabled({ timeout: 15000 });
+    await page.locator('#project-submit').click();
+    await page.waitForURL('**/edit/**', { timeout: 15000 });
+    return page.url();
 }
 
 export async function addFileViaTerminal(page: Page, env: FrameLocator, filename: string) {
-  await env.locator('.xterm-helper-textarea').click();
-  await page.keyboard.type(`echo "hello world" > ${filename}`);
-  await page.keyboard.press('Enter');
-  await page.waitForTimeout(2000);
-  await env.locator('[aria-label="Refresh Explorer"]').first().click();
-  await expect(env.locator(`.monaco-list-row[aria-label*="${filename}"]`)).toBeVisible({ timeout: 15000 });
+    await env.locator('.xterm-helper-textarea').click();
+    await page.keyboard.type(`echo "hello world" > ${filename}`);
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(2000);
+    await env.locator('[aria-label="Refresh Explorer"]').first().click();
+    await expect(env.locator(`.monaco-list-row[aria-label*="${filename}"]`)).toBeVisible({ timeout: 15000 });
 }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -13,118 +13,118 @@ const projectFile = '.auth/test-project.json';
 // Crucially, it never touches Chrome's real passkey store — credentials exist only in memory
 // for the duration of the test.
 async function setupVirtualAuthenticator(page: any, context: any) {
-  const cdp = await context.newCDPSession(page);
-  await cdp.send('WebAuthn.enable', { enableUI: false });
-  await cdp.send('WebAuthn.addVirtualAuthenticator', {
-    options: {
-      protocol: 'ctap2',                // CTAP2 is the protocol used by modern passkeys
-      transport: 'internal',            // 'internal' = platform authenticator (e.g. Face ID / Touch ID)
-      hasResidentKey: true,             // allows the credential to be stored on the authenticator
-      hasUserVerification: true,        // supports biometric/PIN verification
-      isUserVerified: true,             // auto-passes verification (no real biometrics required)
-      automaticPresenceSimulation: true // auto-responds to "tap your key" prompts
-    },
-  });
-  return cdp;
+    const cdp = await context.newCDPSession(page);
+    await cdp.send('WebAuthn.enable', { enableUI: false });
+    await cdp.send('WebAuthn.addVirtualAuthenticator', {
+        options: {
+            protocol: 'ctap2',                // CTAP2 is the protocol used by modern passkeys
+            transport: 'internal',            // 'internal' = platform authenticator (e.g. Face ID / Touch ID)
+            hasResidentKey: true,             // allows the credential to be stored on the authenticator
+            hasUserVerification: true,        // supports biometric/PIN verification
+            isUserVerified: true,             // auto-passes verification (no real biometrics required)
+            automaticPresenceSimulation: true // auto-responds to "tap your key" prompts
+        },
+    });
+    return cdp;
 }
 
 async function waitForMailinatorCode(inboxName: string, timeoutMs = 30000): Promise<string> {
-  const deadline = Date.now() + timeoutMs;
-  const apiKey = process.env.MAILINATOR_API_KEY!;
-  while (Date.now() < deadline) {
-    const domain = process.env.MAILINATOR_DOMAIN!;
-    const inboxRes = await fetch(
-      `https://mailinator.com/api/v2/domains/${domain}/inboxes/${inboxName}`,
-      { headers: { Authorization: apiKey } }
-    );
-    const inbox = await inboxRes.json() as { msgs?: { id: string }[] };
-    if (inbox.msgs && inbox.msgs.length > 0) {
-      const msgRes = await fetch(
-        `https://mailinator.com/api/v2/domains/${domain}/inboxes/${inboxName}/messages/${inbox.msgs[0].id}`,
-        { headers: { Authorization: apiKey } }
-      );
-      const msg = await msgRes.json() as { parts?: { body: string }[] };
-      const body = msg.parts?.[0]?.body ?? '';
-      const match = body.match(/\d{6}/);
-      if (match) return match[0];
+    const deadline = Date.now() + timeoutMs;
+    const apiKey = process.env.MAILINATOR_API_KEY!;
+    while (Date.now() < deadline) {
+        const domain = process.env.MAILINATOR_DOMAIN!;
+        const inboxRes = await fetch(
+            `https://mailinator.com/api/v2/domains/${domain}/inboxes/${inboxName}`,
+            { headers: { Authorization: apiKey } }
+        );
+        const inbox = await inboxRes.json() as { msgs?: { id: string }[] };
+        if (inbox.msgs && inbox.msgs.length > 0) {
+            const msgRes = await fetch(
+                `https://mailinator.com/api/v2/domains/${domain}/inboxes/${inboxName}/messages/${inbox.msgs[0].id}`,
+                { headers: { Authorization: apiKey } }
+            );
+            const msg = await msgRes.json() as { parts?: { body: string }[] };
+            const body = msg.parts?.[0]?.body ?? '';
+            const match = body.match(/\d{6}/);
+            if (match) return match[0];
+        }
+        await new Promise(r => setTimeout(r, 2000));
     }
-    await new Promise(r => setTimeout(r, 2000));
-  }
-  throw new Error('Timed out waiting for Mailinator email');
+    throw new Error('Timed out waiting for Mailinator email');
 }
 
 setup('create test account', async ({ page, context }) => {
-  // Log browser console messages and failed network requests so we can diagnose
-  // issues with the external Hanko API without staring at a blank spinner.
-  page.on('console', (msg: any) => console.log('[browser]', msg.text()));
-  page.on('requestfailed', (req: any) => {
-    const url = new URL(req.url());
-    console.log('[failed request]', url.origin + url.pathname, req.failure()?.errorText);
-  });
+    // Log browser console messages and failed network requests so we can diagnose
+    // issues with the external Hanko API without staring at a blank spinner.
+    page.on('console', (msg: any) => console.log('[browser]', msg.text()));
+    page.on('requestfailed', (req: any) => {
+        const url = new URL(req.url());
+        console.log('[failed request]', url.origin + url.pathname, req.failure()?.errorText);
+    });
 
-  await setupVirtualAuthenticator(page, context);
-  await page.goto('/signin');
+    await setupVirtualAuthenticator(page, context);
+    await page.goto('/signin');
 
-  // Wait for Hanko to finish initialising before interacting with it.
-  const hankoAuth = page.locator('hanko-auth');
-  await hankoAuth.getByRole('button', { name: 'Create account' }).waitFor({ state: 'visible', timeout: 30000 });
-  await hankoAuth.getByRole('button', { name: 'Create account' }).click();
+    // Wait for Hanko to finish initialising before interacting with it.
+    const hankoAuth = page.locator('hanko-auth');
+    await hankoAuth.getByRole('button', { name: 'Create account' }).waitFor({ state: 'visible', timeout: 30000 });
+    await hankoAuth.getByRole('button', { name: 'Create account' }).click();
 
-  const inboxName = `testuser${Date.now()}`;
-  const emailAddress = `${inboxName}@${process.env.MAILINATOR_DOMAIN}`;
+    const inboxName = `testuser${Date.now()}`;
+    const emailAddress = `${inboxName}@${process.env.MAILINATOR_DOMAIN}`;
 
-  await hankoAuth.getByLabel('Username').fill(inboxName);
-  await hankoAuth.getByLabel('Email').fill(emailAddress);
-  await hankoAuth.getByRole('button', { name: 'Continue' }).click();
+    await hankoAuth.getByLabel('Username').fill(inboxName);
+    await hankoAuth.getByLabel('Email').fill(emailAddress);
+    await hankoAuth.getByRole('button', { name: 'Continue' }).click();
 
-  // Hanko occasionally returns a transient "technical error" after form submission.
-  // If that happens, throw so Playwright's retry (retries: 1) re-runs setup.
-  const hankoError = hankoAuth.locator('#errorMessage');
-  if (await hankoError.isVisible({ timeout: 3000 }).catch(() => false)) {
-    throw new Error('Hanko returned a technical error — retrying');
-  }
+    // Hanko occasionally returns a transient "technical error" after form submission.
+    // If that happens, throw so Playwright's retry (retries: 1) re-runs setup.
+    const hankoError = hankoAuth.locator('#errorMessage');
+    if (await hankoError.isVisible({ timeout: 3000 }).catch(() => false)) {
+        throw new Error('Hanko returned a technical error — retrying');
+    }
 
-  // Poll Mailinator for the passcode email and extract the 6-digit code.
-  const code = await waitForMailinatorCode(inboxName);
+    // Poll Mailinator for the passcode email and extract the 6-digit code.
+    const code = await waitForMailinatorCode(inboxName);
 
-  await hankoAuth.locator('input').first().click();
-  await page.keyboard.type(code);
+    await hankoAuth.locator('input').first().click();
+    await page.keyboard.type(code);
 
-  // Hanko may auto-submit when all 6 digits are entered, making Continue disappear.
-  // Wait for whichever comes first, then only click Continue if it's still there.
-  const createPasskeyHeading = hankoAuth.locator('h1').filter({ hasText: 'Create a passkey' });
-  const continueBtn = hankoAuth.getByRole('button', { name: 'Continue' });
-  await Promise.race([
-    createPasskeyHeading.waitFor({ state: 'visible' }),
-    continueBtn.waitFor({ state: 'visible' }),
-  ]);
-  if (await continueBtn.isVisible()) {
-    await continueBtn.click();
-  }
+    // Hanko may auto-submit when all 6 digits are entered, making Continue disappear.
+    // Wait for whichever comes first, then only click Continue if it's still there.
+    const createPasskeyHeading = hankoAuth.locator('h1').filter({ hasText: 'Create a passkey' });
+    const continueBtn = hankoAuth.getByRole('button', { name: 'Continue' });
+    await Promise.race([
+        createPasskeyHeading.waitFor({ state: 'visible' }),
+        continueBtn.waitFor({ state: 'visible' }),
+    ]);
+    if (await continueBtn.isVisible()) {
+        await continueBtn.click();
+    }
 
-  // The virtual authenticator intercepts navigator.credentials.create() automatically.
-  // Wait for the button to detach before waiting for the redirect — this gives the
-  // WebAuthn ceremony time to complete and avoids ERR_ABORTED on the dashboard navigation.
-  await hankoAuth.getByRole('button', { name: 'Create a passkey' }).click();
-  await hankoAuth.getByRole('button', { name: 'Create a passkey' }).waitFor({ state: 'detached', timeout: 15000 });
-  await page.waitForURL('**/dashboard**', { timeout: 30000 });
+    // The virtual authenticator intercepts navigator.credentials.create() automatically.
+    // Wait for the button to detach before waiting for the redirect — this gives the
+    // WebAuthn ceremony time to complete and avoids ERR_ABORTED on the dashboard navigation.
+    await hankoAuth.getByRole('button', { name: 'Create a passkey' }).click();
+    await hankoAuth.getByRole('button', { name: 'Create a passkey' }).waitFor({ state: 'detached', timeout: 15000 });
+    await page.waitForURL('**/dashboard**', { timeout: 30000 });
 
-  // Save cookies + localStorage so all other tests start already logged in.
-  fs.mkdirSync('.auth', { recursive: true });
-  await page.context().storageState({ path: authFile });
+    // Save cookies + localStorage so all other tests start already logged in.
+    fs.mkdirSync('.auth', { recursive: true });
+    await page.context().storageState({ path: authFile });
 
-  // Save the email so teardown.ts can look up and delete this user via the Hanko admin API.
-  fs.writeFileSync(userFile, JSON.stringify({ email: emailAddress }));
+    // Save the email so teardown.ts can look up and delete this user via the Hanko admin API.
+    fs.writeFileSync(userFile, JSON.stringify({ email: emailAddress }));
 
-  // Create a project so editor tests can navigate straight to it without repeating the creation flow.
-  await page.locator('#header-bar.signedin').waitFor({ state: 'visible' });
-  await page.waitForFunction(() => customElements.get('html-component') !== undefined);
-  await page.getByRole('button', { name: 'Create Project' }).click();
-  await page.getByRole('heading', { name: 'New Project' }).waitFor({ state: 'visible', timeout: 30000 });
-  const projectName = `project${Date.now()}`;
-  await page.getByLabel('Project name').fill(projectName);
-  await expect(page.locator('#project-submit')).toBeEnabled({ timeout: 15000 });
-  await page.locator('#project-submit').click();
-  await page.waitForURL('**/edit/**', { timeout: 15000 });
-  fs.writeFileSync(projectFile, JSON.stringify({ url: page.url() }));
+    // Create a project so editor tests can navigate straight to it without repeating the creation flow.
+    await page.locator('#header-bar.signedin').waitFor({ state: 'visible' });
+    await page.waitForFunction(() => customElements.get('html-component') !== undefined);
+    await page.getByRole('button', { name: 'Create Project' }).click();
+    await page.getByRole('heading', { name: 'New Project' }).waitFor({ state: 'visible', timeout: 30000 });
+    const projectName = `project${Date.now()}`;
+    await page.getByLabel('Project name').fill(projectName);
+    await expect(page.locator('#project-submit')).toBeEnabled({ timeout: 15000 });
+    await page.locator('#project-submit').click();
+    await page.waitForURL('**/edit/**', { timeout: 15000 });
+    fs.writeFileSync(projectFile, JSON.stringify({ url: page.url() }));
 });

--- a/tests/teardown.ts
+++ b/tests/teardown.ts
@@ -5,47 +5,47 @@ const userFile = '.auth/test-user.json';
 const projectFile = '.auth/test-project.json';
 
 teardown('delete test account', async () => {
-  if (!fs.existsSync(userFile)) {
-    console.log('[teardown] No test user file found, skipping.');
-    return;
-  }
+    if (!fs.existsSync(userFile)) {
+        console.log('[teardown] No test user file found, skipping.');
+        return;
+    }
 
-  const { email } = JSON.parse(fs.readFileSync(userFile, 'utf-8'));
-  const adminApiKey = process.env.HANKO_ADMIN_API_KEY!;
-  const adminUrl = `${process.env.AUTH_URL}/admin/users`;;
+    const { email } = JSON.parse(fs.readFileSync(userFile, 'utf-8'));
+    const adminApiKey = process.env.HANKO_ADMIN_API_KEY!;
+    const adminUrl = `${process.env.AUTH_URL}/admin/users`;;
 
-  const headers = {
-    Authorization: `Bearer ${adminApiKey}`,
-    'Content-Type': 'application/json',
-  };
+    const headers = {
+        Authorization: `Bearer ${adminApiKey}`,
+        'Content-Type': 'application/json',
+    };
 
-  // Look up the user by email to get their ID.
-  const listRes = await fetch(`${adminUrl}?email=${encodeURIComponent(email)}`, { headers });
-  if (!listRes.ok) {
-    throw new Error(`Failed to list users: ${listRes.status} ${await listRes.text()}`);
-  }
+    // Look up the user by email to get their ID.
+    const listRes = await fetch(`${adminUrl}?email=${encodeURIComponent(email)}`, { headers });
+    if (!listRes.ok) {
+        throw new Error(`Failed to list users: ${listRes.status} ${await listRes.text()}`);
+    }
 
-  const users = await listRes.json() as Array<{ id: string }>;
-  if (users.length === 0) {
-    console.log(`[teardown] No Hanko user found for ${email}, skipping delete.`);
-    return;
-  }
+    const users = await listRes.json() as Array<{ id: string }>;
+    if (users.length === 0) {
+        console.log(`[teardown] No Hanko user found for ${email}, skipping delete.`);
+        return;
+    }
 
-  const userId = users[0].id;
+    const userId = users[0].id;
 
-  // Delete the user.
-  const deleteRes = await fetch(`${adminUrl}/${userId}`, { method: 'DELETE', headers });
-  if (!deleteRes.ok && deleteRes.status !== 404) {
-    throw new Error(`Failed to delete user ${userId}: ${deleteRes.status} ${await deleteRes.text()}`);
-  }
+    // Delete the user.
+    const deleteRes = await fetch(`${adminUrl}/${userId}`, { method: 'DELETE', headers });
+    if (!deleteRes.ok && deleteRes.status !== 404) {
+        throw new Error(`Failed to delete user ${userId}: ${deleteRes.status} ${await deleteRes.text()}`);
+    }
 
-  // Verify the user is gone — expect a 404.
-  const verifyRes = await fetch(`${adminUrl}/${userId}`, { headers });
-  if (verifyRes.status !== 404) {
-    throw new Error(`Expected user ${userId} to be deleted but got status ${verifyRes.status}`);
-  }
+    // Verify the user is gone — expect a 404.
+    const verifyRes = await fetch(`${adminUrl}/${userId}`, { headers });
+    if (verifyRes.status !== 404) {
+        throw new Error(`Expected user ${userId} to be deleted but got status ${verifyRes.status}`);
+    }
 
-  console.log(`[teardown] Deleted and verified removal of Hanko user ${userId} (${email})`);
-  fs.unlinkSync(userFile);
-  if (fs.existsSync(projectFile)) fs.unlinkSync(projectFile);
+    console.log(`[teardown] Deleted and verified removal of Hanko user ${userId} (${email})`);
+    fs.unlinkSync(userFile);
+    if (fs.existsSync(projectFile)) fs.unlinkSync(projectFile);
 });

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -1,37 +1,37 @@
-  
+    
 interface ValidationResponse {
-    is_valid: boolean;
+        is_valid: boolean;
 }
 
 export async function validateToken(hankoApiUrl: string, token: string): Promise<boolean> {
-  if (!token || token.length === 0) {
-    return false;
-  }
-
-  try {
-    const response = await fetch(`${hankoApiUrl}/sessions/validate`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ session_token: token }),
-      redirect: 'manual',
-    });
-
-    if (!response.ok) {
-      return false;
+    if (!token || token.length === 0) {
+        return false;
     }
 
-    const validationData = await response.json() as ValidationResponse;
-    return validationData.is_valid;
-  } catch (error) {
-    console.error('Token validation error:', error);
-    return false;
-  }
+    try {
+        const response = await fetch(`${hankoApiUrl}/sessions/validate`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ session_token: token }),
+            redirect: 'manual',
+        });
+
+        if (!response.ok) {
+            return false;
+        }
+
+        const validationData = await response.json() as ValidationResponse;
+        return validationData.is_valid;
+    } catch (error) {
+        console.error('Token validation error:', error);
+        return false;
+    }
 }
 
 export function parseJWT(token: string): Record<string, any> {
-  const base64Url = token.split('.')[1];
-  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-  return JSON.parse(atob(base64));
+    const base64Url = token.split('.')[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    return JSON.parse(atob(base64));
 }

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -1,37 +1,37 @@
-    
+  
 interface ValidationResponse {
-        is_valid: boolean;
+    is_valid: boolean;
 }
 
 export async function validateToken(hankoApiUrl: string, token: string): Promise<boolean> {
-    if (!token || token.length === 0) {
-        return false;
+  if (!token || token.length === 0) {
+    return false;
+  }
+
+  try {
+    const response = await fetch(`${hankoApiUrl}/sessions/validate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ session_token: token }),
+      redirect: 'manual',
+    });
+
+    if (!response.ok) {
+      return false;
     }
 
-    try {
-        const response = await fetch(`${hankoApiUrl}/sessions/validate`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ session_token: token }),
-            redirect: 'manual',
-        });
-
-        if (!response.ok) {
-            return false;
-        }
-
-        const validationData = await response.json() as ValidationResponse;
-        return validationData.is_valid;
-    } catch (error) {
-        console.error('Token validation error:', error);
-        return false;
-    }
+    const validationData = await response.json() as ValidationResponse;
+    return validationData.is_valid;
+  } catch (error) {
+    console.error('Token validation error:', error);
+    return false;
+  }
 }
 
 export function parseJWT(token: string): Record<string, any> {
-    const base64Url = token.split('.')[1];
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    return JSON.parse(atob(base64));
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  return JSON.parse(atob(base64));
 }

--- a/worker/src/public.ts
+++ b/worker/src/public.ts
@@ -155,8 +155,8 @@ ${assets.map(a => `dirname(import.meta.url)+'${a}'`).join(",\n")}
 }
 
 function dirname(path) {
-    const i = path.lastIndexOf('/');
-    return i === -1 ? '.' : i === 0 ? '/' : path.slice(0, i);
+  const i = path.lastIndexOf('/');
+  return i === -1 ? '.' : i === 0 ? '/' : path.slice(0, i);
 }
 `;
 }

--- a/worker/src/public.ts
+++ b/worker/src/public.ts
@@ -155,8 +155,8 @@ ${assets.map(a => `dirname(import.meta.url)+'${a}'`).join(",\n")}
 }
 
 function dirname(path) {
-  const i = path.lastIndexOf('/');
-  return i === -1 ? '.' : i === 0 ? '/' : path.slice(0, i);
+    const i = path.lastIndexOf('/');
+    return i === -1 ? '.' : i === 0 ? '/' : path.slice(0, i);
 }
 `;
 }


### PR DESCRIPTION
Standardizes indentation across tests/, worker/src/, and assets/ to match the 4-space convention used elsewhere in the repo. Also fixes two pre-existing indentation inconsistencies uncovered in the process: a mixed 2/4-space styles.css reindented by brace depth, and a 2-line over-indentation bug in _frame.html's isLocalhost().